### PR TITLE
Feature/5-cart

### DIFF
--- a/src/main/java/flab/commercemarket/cart/controller/CartController.java
+++ b/src/main/java/flab/commercemarket/cart/controller/CartController.java
@@ -1,0 +1,68 @@
+package flab.commercemarket.cart.controller;
+
+import flab.commercemarket.cart.domain.Cart;
+import flab.commercemarket.cart.dto.CartDto;
+import flab.commercemarket.cart.dto.CartResponseDto;
+import flab.commercemarket.cart.service.CartService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/carts")
+@RequiredArgsConstructor
+public class CartController {
+
+    private final CartService cartService;
+
+    @PostMapping
+    public CartResponseDto postCart(@RequestBody CartDto cartDto) {
+        Cart data = cartDto.toCart();
+        long loginUserId = data.getUserId(); // todo 토큰에서 조회하도록 변경
+
+        Cart registerCart = cartService.registerCart(data, loginUserId);
+        return registerCart.toCartResponseDto();
+    }
+
+    @PatchMapping("/{cartId}")
+    public CartResponseDto patchCart(@PathVariable("cartId") long cartId,
+                                     @RequestBody CartDto cartDto) {
+        // todo 로그인 기능 추가 이후 해당 장바구니 수정에 대한 권한 검증로직이 추가되어야 합니다.
+        Cart data = cartDto.toCart();
+        long userId = data.getUserId(); // todo 토큰에서 조회하도록 변경
+
+        Cart updatedCart = cartService.updateCart(data, cartId, userId);
+        return updatedCart.toCartResponseDto();
+    }
+
+    /*
+     * @param userId
+     * @param page
+     * @return 특정 사용자의 장바구니 리스트
+     */
+    @GetMapping
+    public List<CartResponseDto> getCarts(@RequestParam long userId) {
+        // todo 로그인 기능 추가 이후 userId를 조회하는 로직 변경 -> 토큰에서 조회 등
+        List<Cart> carts = cartService.getCarts(userId);
+        return carts.stream()
+                .map(Cart::toCartResponseDto)
+                .collect(Collectors.toList());
+    }
+
+    @DeleteMapping("/{cartId}")
+    public void deleteCart(@PathVariable long cartId) {
+        // todo 로그인 기능 추가 이후 해당 장바구니 삭제에 대한 권한 검증로직이 추가되어야 합니다.
+        long loginUserId = 1L; // 토큰에서 조회하는 로직으로 변경해야함
+        cartService.deleteCart(cartId, loginUserId);
+    }
+
+    @GetMapping("/{userId}")
+    public int getPrice(@PathVariable long userId) {
+        // todo 로그인 기능 추가 이후 userId를 조회하는 로직 변경
+        return cartService.calculateTotalPrice(userId);
+    }
+}
+
+

--- a/src/main/java/flab/commercemarket/cart/domain/Cart.java
+++ b/src/main/java/flab/commercemarket/cart/domain/Cart.java
@@ -1,0 +1,30 @@
+package flab.commercemarket.cart.domain;
+
+import flab.commercemarket.cart.dto.CartResponseDto;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class Cart {
+    private Long id;
+    private long userId;
+    private long productId;
+    private int quantity;
+
+    @Builder
+    public Cart(long userId, long productId, int quantity) {
+        this.userId = userId;
+        this.productId = productId;
+        this.quantity = quantity;
+    }
+
+    public CartResponseDto toCartResponseDto() {
+        return CartResponseDto.builder()
+                .id(id)
+                .userId(userId)
+                .productId(productId)
+                .quantity(quantity)
+                .build();
+    }
+}

--- a/src/main/java/flab/commercemarket/cart/dto/CartDto.java
+++ b/src/main/java/flab/commercemarket/cart/dto/CartDto.java
@@ -3,10 +3,8 @@ package flab.commercemarket.cart.dto;
 import flab.commercemarket.cart.domain.Cart;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Getter
-@Setter
 @NoArgsConstructor
 public class CartDto {
     private long userId;

--- a/src/main/java/flab/commercemarket/cart/dto/CartDto.java
+++ b/src/main/java/flab/commercemarket/cart/dto/CartDto.java
@@ -1,0 +1,23 @@
+package flab.commercemarket.cart.dto;
+
+import flab.commercemarket.cart.domain.Cart;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class CartDto {
+    private long userId;
+    private long productId;
+    private int quantity;
+
+    public Cart toCart() {
+        return Cart.builder()
+                .userId(userId)
+                .productId(productId)
+                .quantity(quantity)
+                .build();
+    }
+}

--- a/src/main/java/flab/commercemarket/cart/dto/CartResponseDto.java
+++ b/src/main/java/flab/commercemarket/cart/dto/CartResponseDto.java
@@ -1,0 +1,15 @@
+package flab.commercemarket.cart.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CartResponseDto {
+    private Long id;
+    private long userId;
+    private long productId;
+    private int quantity;
+}

--- a/src/main/java/flab/commercemarket/cart/dto/CartResponseDto.java
+++ b/src/main/java/flab/commercemarket/cart/dto/CartResponseDto.java
@@ -3,7 +3,6 @@ package flab.commercemarket.cart.dto;
 import lombok.*;
 
 @Getter
-@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/flab/commercemarket/cart/mapper/CartMapper.java
+++ b/src/main/java/flab/commercemarket/cart/mapper/CartMapper.java
@@ -1,0 +1,24 @@
+package flab.commercemarket.cart.mapper;
+
+import flab.commercemarket.cart.domain.Cart;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
+import java.util.Optional;
+
+@Mapper
+public interface CartMapper {
+
+    void createCart(Cart cart);
+
+    void updateCart(Cart cart);
+
+    Optional<Cart> findById(long cartId);
+
+    boolean checkCartExistence(long userId, long productId);
+
+    List<Cart> findAll(long userId);
+
+    void deleteCart(long cartId);
+
+}

--- a/src/main/java/flab/commercemarket/cart/service/CartService.java
+++ b/src/main/java/flab/commercemarket/cart/service/CartService.java
@@ -1,0 +1,96 @@
+package flab.commercemarket.cart.service;
+
+import flab.commercemarket.cart.domain.Cart;
+import flab.commercemarket.cart.mapper.CartMapper;
+import flab.commercemarket.exception.DataNotFoundException;
+import flab.commercemarket.exception.DuplicateDataException;
+import flab.commercemarket.exception.ForbiddenException;
+import flab.commercemarket.product.service.ProductService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+
+@Service
+@RequiredArgsConstructor
+public class CartService {
+    private final CartMapper cartMapper;
+    private final ProductService productService;
+
+    public Cart registerCart(Cart data, long userId) {
+        checkUserAuthorization(data.getUserId(), userId);
+        validateUserAndProductExistence(data);
+        checkDuplicateCartItem(userId, data.getProductId());
+
+        cartMapper.createCart(data);
+        return data;
+    }
+
+    public Cart updateCart(Cart data, long cartId, long userId) {
+        Cart foundCart = verifiedCart(cartId);
+        checkUserAuthorization(foundCart.getUserId(), userId);
+
+        // userID와 productId는 수정되면 안된다. -> foundCart 값을 그대로 입력
+        foundCart.setUserId(foundCart.getUserId());
+        foundCart.setProductId(foundCart.getProductId());
+        foundCart.setQuantity(data.getQuantity());
+        cartMapper.updateCart(foundCart);
+        return foundCart;
+    }
+
+    public List<Cart> getCarts(long userId) {
+        // todo 테이블의 모든 항목을 쿼리해온다. -> 성능이슈 예상
+        // todo 페이징 처리 등 개선방법 생각해보기
+        return cartMapper.findAll(userId);
+    }
+
+
+    public void deleteCart(long cartId, long userId) {
+        Cart cart = verifiedCart(cartId);
+        if (cart.getUserId() != userId) {
+            throw new ForbiddenException("유저 권한정보가 일치하지 않음");
+        }
+
+        cartMapper.deleteCart(cartId);
+    }
+
+    public int calculateTotalPrice(long userId) {
+        List<Cart> carts = getCarts(userId);
+
+        int sum = 0;
+        // 성능이슈 예상지점
+        // TODO for루프, 순차스트림, 병렬스트림 성능비교 -> JMH 사용
+        // TODO findProduct -> 상품 리스트 하나당 쿼리 하나가 나가는 로직 개선해야함
+        for (Cart cart : carts) {
+            int quantity = cart.getQuantity();
+            long productId = cart.getProductId();
+            int price = productService.findProduct(productId).getPrice();
+            sum += quantity * price;
+        }
+        return sum;
+    }
+
+    private Cart verifiedCart(long cartId) {
+        Optional<Cart> optionalCart = cartMapper.findById(cartId);
+        return optionalCart.orElseThrow(() -> new DataNotFoundException("조회한 장바구니 정보가 없음"));
+    }
+
+    private void checkUserAuthorization(long cartUserId, long loginUserId) {
+        if (cartUserId != loginUserId) {
+            throw new ForbiddenException("유저권한정보가 일치하지 않음");
+        }
+    }
+
+    private void validateUserAndProductExistence(Cart data) {
+        productService.getVerifiedProduct(data.getProductId());
+//        userService.getVerifiedUser(data.getUserId());
+    }
+
+    private void checkDuplicateCartItem(long userId, long productId) {
+        if (cartMapper.checkCartExistence(userId, productId)) {
+            throw new DuplicateDataException("이미 장바구니에 담긴 상품");
+        }
+    }
+}

--- a/src/main/java/flab/commercemarket/config/MyBatisConfig.java
+++ b/src/main/java/flab/commercemarket/config/MyBatisConfig.java
@@ -1,0 +1,39 @@
+package flab.commercemarket.config;
+
+
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.mybatis.spring.SqlSessionFactoryBean;
+import org.mybatis.spring.annotation.MapperScan;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+
+import javax.sql.DataSource;
+
+@Configuration
+@MapperScan("flab.commercemarket.*.mapper")
+public class MyBatisConfig {
+
+    private final DataSource dataSource;
+
+    public MyBatisConfig(DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Bean
+    public SqlSessionFactory sqlSessionFactory() throws Exception {
+        SqlSessionFactoryBean sessionFactoryBean = new SqlSessionFactoryBean();
+        sessionFactoryBean.setDataSource(dataSource);
+        sessionFactoryBean.setMapperLocations(new PathMatchingResourcePatternResolver().getResources("classpath*:mybatis/**/*.xml"));
+        sessionFactoryBean.setConfiguration(mybatisConfiguration());
+        return sessionFactoryBean.getObject();
+    }
+
+    @Bean
+    public org.apache.ibatis.session.Configuration mybatisConfiguration() {
+        org.apache.ibatis.session.Configuration configuration = new org.apache.ibatis.session.Configuration();
+        configuration.setMapUnderscoreToCamelCase(true);
+        return configuration;
+    }
+}
+

--- a/src/main/java/flab/commercemarket/exception/DuplicateDataException.java
+++ b/src/main/java/flab/commercemarket/exception/DuplicateDataException.java
@@ -1,0 +1,11 @@
+package flab.commercemarket.exception;
+
+public class DuplicateDataException extends RuntimeException {
+    public DuplicateDataException(String message) {
+        super(message);
+    }
+
+    public DuplicateDataException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/flab/commercemarket/exception/ForbiddenException.java
+++ b/src/main/java/flab/commercemarket/exception/ForbiddenException.java
@@ -1,0 +1,11 @@
+package flab.commercemarket.exception;
+
+public class ForbiddenException extends RuntimeException {
+    public ForbiddenException(String message) {
+        super(message);
+    }
+
+    public ForbiddenException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/flab/commercemarket/helper/AuthorizationHelper.java
+++ b/src/main/java/flab/commercemarket/helper/AuthorizationHelper.java
@@ -1,0 +1,14 @@
+package flab.commercemarket.helper;
+
+import flab.commercemarket.exception.ForbiddenException;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AuthorizationHelper {
+
+    public void checkUserAuthorization(long cartUserId, long loginUserId) {
+        if (cartUserId != loginUserId) {
+            throw new ForbiddenException("유저권한정보가 일치하지 않음");
+        }
+    }
+}

--- a/src/main/java/flab/commercemarket/product/dto/ProductResponseDto.java
+++ b/src/main/java/flab/commercemarket/product/dto/ProductResponseDto.java
@@ -2,8 +2,9 @@ package flab.commercemarket.product.dto;
 
 import lombok.*;
 
-@Data
 @Builder
+@Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 public class ProductResponseDto {

--- a/src/main/java/flab/commercemarket/product/service/ProductService.java
+++ b/src/main/java/flab/commercemarket/product/service/ProductService.java
@@ -58,7 +58,7 @@ public class ProductService {
         productMapper.deleteProduct(id);
     }
 
-    private Product getVerifiedProduct(Long id) {
+    public Product getVerifiedProduct(long id) {
         Optional<Product> optionalProduct = productMapper.findById(id);
         return optionalProduct.orElseThrow(() -> new DataNotFoundException("조회한 상품 정보가 없음"));
     }

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -5,8 +5,8 @@ spring:
     password:
     driver-class-name: org.h2.Driver
 
-mybatis:
-  type-aliases-package: flab.commercemarket
-  mapper-locations: mybatis/**/*.xml
-  configuration:
-    map-underscore-to-camel-case: true
+#mybatis:
+#  type-aliases-package: flab.commercemarket
+#  mapper-locations: mybatis/**/*.xml
+#  configuration:
+#    map-underscore-to-camel-case: true

--- a/src/main/resources/mybatis/cart-mapper.xml
+++ b/src/main/resources/mybatis/cart-mapper.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper  PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="flab.commercemarket.cart.mapper.CartMapper">
+    <resultMap id="cartResultMap" type="flab.commercemarket.cart.domain.Cart">
+        <id property="id" column="id" />
+        <result property="userId" column="user_id" />
+        <result property="productId" column="product_id" />
+        <result property="quantity" column="quantity" />
+    </resultMap>
+
+    <insert id="createCart" parameterType="flab.commercemarket.cart.domain.Cart" useGeneratedKeys="true" keyProperty="id">
+        INSERT INTO cart (user_id, product_id, quantity)
+        VALUES (#{userId}, #{productId}, #{quantity})
+    </insert>
+
+    <update id="updateCart" parameterType="flab.commercemarket.cart.domain.Cart">
+        UPDATE cart
+        SET
+            user_id = #{userId},
+            product_id = #{productId},
+            quantity = #{quantity}
+        WHERE
+            id = #{id}
+    </update>
+
+    <select id="findById" parameterType="long" resultMap="cartResultMap">
+        SELECT * FROM cart WHERE id = #{id}
+    </select>
+
+    <select id="findAll" parameterType="long" resultMap="cartResultMap">
+        SELECT * FROM cart WHERE user_id = #{userId}
+    </select>
+
+    <delete id="deleteCart" parameterType="long">
+        DELETE FROM cart WHERE id = #{id}
+    </delete>
+
+
+    <select id="checkCartExistence" resultType="boolean">
+        SELECT EXISTS(
+                       SELECT 1 FROM cart
+                       WHERE user_id = #{userId} AND product_id = #{productId}
+                   ) AS exist
+    </select>
+</mapper>

--- a/src/test/java/flab/commercemarket/cart/service/CartServiceTest.java
+++ b/src/test/java/flab/commercemarket/cart/service/CartServiceTest.java
@@ -5,6 +5,7 @@ import flab.commercemarket.cart.mapper.CartMapper;
 import flab.commercemarket.exception.DataNotFoundException;
 import flab.commercemarket.exception.DuplicateDataException;
 import flab.commercemarket.exception.ForbiddenException;
+import flab.commercemarket.helper.AuthorizationHelper;
 import flab.commercemarket.product.domain.Product;
 import flab.commercemarket.product.service.ProductService;
 import org.junit.jupiter.api.BeforeEach;
@@ -19,6 +20,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
@@ -29,6 +31,9 @@ class CartServiceTest {
 
     @Mock
     private ProductService productService;
+
+    @Mock
+    private AuthorizationHelper authorizationHelper;
 
     @InjectMocks
     private CartService cartService;
@@ -165,7 +170,7 @@ class CartServiceTest {
     }
 
     @Test
-    @DisplayName("인증된 user와 장바구니에 저정되어있는 user 정보가 다르면 예외를 발생시킨디ㅏ.")
+    @DisplayName("인증된 user와 장바구니에 저정되어있는 user 정보가 다르면 예외를 발생시킨다.")
     public void updateCartTest_unauthorizedUser() throws Exception {
         // given
         long userId = 1L;
@@ -179,6 +184,8 @@ class CartServiceTest {
         long deniedUserId = 2L;
         Cart data = new Cart(deniedUserId, productId, 2);
         data.setId(cartId);
+
+        doThrow(new ForbiddenException("유저 권한 정보가 일치하지 않음")).when(authorizationHelper).checkUserAuthorization(userId, deniedUserId);
 
         assertThrows(ForbiddenException.class, () -> {
             cartService.updateCart(data, cartId, deniedUserId);

--- a/src/test/java/flab/commercemarket/cart/service/CartServiceTest.java
+++ b/src/test/java/flab/commercemarket/cart/service/CartServiceTest.java
@@ -1,0 +1,307 @@
+package flab.commercemarket.cart.service;
+
+import flab.commercemarket.cart.domain.Cart;
+import flab.commercemarket.cart.mapper.CartMapper;
+import flab.commercemarket.exception.DataNotFoundException;
+import flab.commercemarket.exception.DuplicateDataException;
+import flab.commercemarket.exception.ForbiddenException;
+import flab.commercemarket.product.domain.Product;
+import flab.commercemarket.product.service.ProductService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+class CartServiceTest {
+
+    @Mock
+    private CartMapper cartMapper;
+
+    @Mock
+    private ProductService productService;
+
+    @InjectMocks
+    private CartService cartService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    public void notNullCheck() throws Exception {
+        assertThat(cartService).isNotNull();
+        assertThat(cartMapper).isNotNull();
+        assertThat(productService).isNotNull();
+    }
+
+    @Test
+    public void registerCartTest_successfulRegister() throws Exception {
+        // given
+        long productId = 1L;
+        long userId = 1L;
+        Cart data = makeCartFixture();
+
+        // when
+        when(productService.getVerifiedProduct(productId)).thenReturn(new Product());
+        Cart registerCart = cartService.registerCart(data, userId);
+
+        // then
+        assertThat(data.getUserId()).isEqualTo(registerCart.getUserId());
+        assertThat(data.getProductId()).isEqualTo(registerCart.getProductId());
+        assertThat(data.getQuantity()).isEqualTo(registerCart.getQuantity());
+    }
+
+    @Test
+    @DisplayName("testUpdateCart_unauthorizedUser 테스트에서 커버")
+    public void 유저_권한_검증() throws Exception {
+    }
+
+    @Test
+    @DisplayName("장바구니에 등록할 상품정보가 존재하지 않을때 예외를 발생시킨다.")
+    public void registerCartTest_not_found_product() throws Exception {
+        // given
+        long userId = 1L;
+        long productId = 1L;
+        Cart data = makeCartFixture();
+
+        // when
+        when(productService.getVerifiedProduct(productId)).thenThrow(new DataNotFoundException("조회한 상품 정보가 없음"));
+
+        // then
+        assertThrows(DataNotFoundException.class, () -> {
+            cartService.registerCart(data, userId);
+        });
+    }
+
+    @Test
+    @DisplayName("장바구니에 이미 존재하는 상품을 다시 담으면 예외가 발생한다.")
+    public void registerCartTest_duplicate_product() throws Exception {
+        // given
+        long userId = 1L;
+        long productId = 1L;
+        Cart data = makeCartFixture();
+
+        // when
+        when(productService.getVerifiedProduct(productId)).thenReturn(new Product());
+        when(cartMapper.checkCartExistence(userId, productId)).thenReturn(true);
+
+        // then
+        assertThrows(DuplicateDataException.class, () -> {
+            cartService.registerCart(data, userId);
+        });
+    }
+
+    @Test
+    @DisplayName("업데이할 수량의 정보를 입력받아 정보를 수정해야한다.")
+    void updateCartTest_successfulUpdate() {
+        // given
+        long cartId = 1L;
+        long userId = 1L;
+        long productId = 1L;
+
+        Cart existCart = makeCartFixture();
+
+        // when
+        when(cartMapper.findById(cartId)).thenReturn(Optional.of(existCart));
+        Cart data = new Cart(userId, productId, 100);
+        data.setId(cartId);
+
+        Cart result = cartService.updateCart(data, cartId, userId);
+
+        // then
+        assertThat(existCart.getId()).isEqualTo(result.getId());
+        assertThat(existCart.getUserId()).isEqualTo(result.getUserId());
+        assertThat(existCart.getProductId()).isEqualTo(result.getProductId());
+        assertThat(data.getQuantity()).isEqualTo(result.getQuantity());
+    }
+
+    @Test
+    @DisplayName("user와 product의 정보는 업데이트되면 안되고 quantity만 업데이트 되어야한다.")
+    public void updateCartTest_do_not_change_userAndProduct_info() throws Exception {
+        // given
+        long cartId = 1L;
+        long userId = 1L;
+        Cart existCart = makeCartFixture();
+
+        // when
+        when(cartMapper.findById(cartId)).thenReturn(Optional.of(existCart));
+        Cart data = new Cart(100L, 100L, 10);
+        Cart result = cartService.updateCart(data, cartId, userId);
+
+        // then
+        assertThat(result.getUserId()).isNotEqualTo(data.getUserId());
+        assertThat(result.getProductId()).isNotEqualTo(data.getProductId());
+        assertThat(result.getUserId()).isEqualTo(existCart.getUserId());
+        assertThat(result.getProductId()).isEqualTo(existCart.getUserId());
+        assertThat(result.getQuantity()).isEqualTo(data.getQuantity());
+    }
+
+    @Test
+    @DisplayName("장바구니 정보가 조회되지 않으면 예외를 발생시켜야한다.")
+    public void updateCartTest_cartNotFount() throws Exception {
+        // given
+        long userId = 1L;
+        long cartId = 1L;
+
+        // when
+        when(cartMapper.findById(cartId)).thenReturn(Optional.empty());
+        Cart data = new Cart(100L, 100L, 10);
+
+        // then
+        assertThrows(DataNotFoundException.class, () -> {
+            cartService.updateCart(data, cartId, userId);
+        });
+    }
+
+    @Test
+    @DisplayName("인증된 user와 장바구니에 저정되어있는 user 정보가 다르면 예외를 발생시킨디ㅏ.")
+    public void updateCartTest_unauthorizedUser() throws Exception {
+        // given
+        long userId = 1L;
+        long productId = 1L;
+        long cartId = 1L;
+        Cart existCart = new Cart(userId, productId, 1);
+        existCart.setId(cartId);
+
+        when(cartMapper.findById(cartId)).thenReturn(Optional.of(existCart));
+
+        long deniedUserId = 2L;
+        Cart data = new Cart(deniedUserId, productId, 2);
+        data.setId(cartId);
+
+        assertThrows(ForbiddenException.class, () -> {
+            cartService.updateCart(data, cartId, deniedUserId);
+        });
+    }
+
+    @Test
+    @DisplayName("유저의 장바구니 목록을 전체 조회")
+    void getCarts() {
+        long userId = 1L;
+
+        List<Cart> expectedCartList = Arrays.asList(
+                new Cart(1L, 1L, 10),
+                new Cart(1L, 2L, 20),
+                new Cart(1L, 3L, 30)
+        );
+
+        when(cartService.getCarts(userId)).thenReturn(expectedCartList);
+        List<Cart> result = cartService.getCarts(userId);
+
+        assertThat(result.size()).isEqualTo(3);
+        for (Cart cart : result) {
+            assertThat(cart.getUserId()).isEqualTo(userId);
+        }
+    }
+
+    @Test
+    public void deleteCartTest_successful() throws Exception {
+        // given
+        long cartId = 1L;
+        long userId = 1L;
+        Cart cart = makeCartFixture();
+
+        // when
+        when(cartMapper.findById(cartId)).thenReturn(Optional.of(cart));
+
+        // then
+        cartService.deleteCart(cartId, userId);
+        verify(cartMapper, times(1)).deleteCart(cartId);
+    }
+
+    @Test
+    @DisplayName("유저 권한 정보가 일치하지 않으면 Forbidden 예외를 발생시킨다.")
+    void deleteCartTest_forbidden() {
+        long cartId = 1L;
+        long userId = 1L;
+        Cart existCart = makeCartFixture();
+
+        when(cartMapper.findById(cartId)).thenReturn(Optional.of(existCart));
+
+        long deniedUserId = 2L; // 유저 권한 정보가 다름
+        assertThrows(ForbiddenException.class, () -> {
+            cartService.deleteCart(cartId, deniedUserId);
+        });
+
+        verify(cartMapper,times(0)).deleteCart(cartId);
+    }
+
+    @Test
+    void calculateTotalPrice() {
+        long userId = 1L;
+
+        List<Cart> cartList = Arrays.asList( // 130_000원
+                new Cart(1L, 1L, 2), // 10000원 x 2개
+                new Cart(1L, 2L, 1), // 20000원 x 1개
+                new Cart(1L, 3L, 3) // 30000원 x 3개
+        );
+
+        List<Product> productList = makeProductListFixture();
+
+        when(cartService.getCarts(userId)).thenReturn(cartList);
+        when(productService.findProduct(1L)).thenReturn(productList.get(0));
+        when(productService.findProduct(2L)).thenReturn(productList.get(1));
+        when(productService.findProduct(3L)).thenReturn(productList.get(2));
+
+        int expectedSum = calculateExpectedSum(cartList, productList);
+        int actualSum = cartService.calculateTotalPrice(userId);
+
+        assertThat(actualSum).isEqualTo(expectedSum);
+    }
+
+    private int calculateExpectedSum(List<Cart> cartList, List<Product> productList) {
+        int sum = 0;
+
+        for (Cart cart : cartList) {
+            int quantity = cart.getQuantity();
+            int price = getPrice(cart.getProductId(), productList);
+            sum += quantity * price;
+        }
+        return sum;
+    }
+
+    private int getPrice(long productId, List<Product> productList) {
+        for (Product product : productList) {
+            if (product.getId() == productId) {
+                return product.getPrice();
+            }
+        }
+        throw new DataNotFoundException("상품 정보를 찾을 수 없음 " + productId);
+    }
+
+    private Cart makeCartFixture() {
+        Cart cart = new Cart(1L, 1L, 1);
+        cart.setId(1L);
+        return cart;
+    }
+
+    private List<Product> makeProductListFixture() {
+        Product product1 = new Product();
+        product1.setId(1L);
+        product1.setName("Product 1");
+        product1.setPrice(10000);
+
+        Product product2 = new Product();
+        product2.setId(2L);
+        product2.setName("Product 2");
+        product2.setPrice(20000);
+
+        Product product3 = new Product();
+        product3.setId(3L);
+        product3.setName("Product 3");
+        product3.setPrice(30000);
+
+        return Arrays.asList(product1, product2, product3);
+    }
+}


### PR DESCRIPTION
## 장바구니 기능 구현


### 목적

구매자가 원하는 상품을 장바구니에 추가하고 상품들을 확인, 수정, 삭제할 수 있도록 합니다. 장바구니 기능을 통해 사용자는 여러 상품을 한곳에 모아 관리할 수 있습니다. 또한 장바구니에 담긴 상품들의 가격을 계산하여 총 가격을 표시해주어 결재 과정을 간소화 할 수 있습니다.

### 내용

장바구니 관련 CRUD 기능 구현
- Create: 사용자는 장바구니에 원하는 상품을 등록할 수 있습니다.
- Update: 사용자는 장바구니에 담은 상품의 개수를 수정할 수 있습니다.
- Read: 사용자는 장바구니에 담은 전체 목록을 확인할 수 있습니다.
- Read: 사용자는 장바구니에 담은 상품의 총 가격을 확인할 수 있습니다.
- Delete: 사용자는 장바구니에 담긴 상품을 삭제할 수 있습니다.

### 영향

장바구니 기능을 통해 사용자는 여러 상품을 한곳에 모아서 관리할 수 있습니다. 또한 장바구니에 담긴 상품들의 가격을 계산하여 총 가격을 표시해주면서 결제 과정을 간소화 시킬 수 있습니다.

### 관련 이슈

#5 

### 참고 사항

현재 예상되는 성능 문제는 다음과 같습니다. #19 

`calculateTotalPrice()` 계산 로직 성능 비교

- 현재 calculateTotalPrice() 메서드에서는 for 루프를 사용하여 계산을 수행하고 있습니다. 해당 로직에 대해 JMH 라이브러리를 사용하여 순차스트림, 병렬스트림을 비교한뒤 최적화 하는 작업을 수행해야합니다.
- 현재 /carts/4 엔드포인트로 GET 요청을 보내 값을 받아오도록 구현되어 있습니다. 그러나 장바구니에 상품이 추가되면 실시간으로 장바구니의 금액이 업데이트되는 기능을 고려할 수 있습니다. 추후 Server-Sent Events와 같은 관련 기술을 찾아볼 계획입니다.

`getCarts()` 쿼리 최적화

- 현재 cart 테이블에서는 user_id가 1인 유저의 장바구니 목록을 가져오는 쿼리가 `SELECT * FROM cart WHERE user_id = #{userId}`로 작성되어 있습니다. 위 쿼리는 `cart` 테이블 내의 모든 데이터를 쿼리해와야 하는 비효율적인 문제가 있습니다. 
- 이를 해결하기 위해 페이징 처리나 캐싱을 고려해 볼 계획입니다.