### PR TITLE
Refactor/34-product-pagination

### DIFF
--- a/src/main/java/flab/commercemarket/controller/product/ProductController.java
+++ b/src/main/java/flab/commercemarket/controller/product/ProductController.java
@@ -1,5 +1,6 @@
 package flab.commercemarket.controller.product;
 
+import flab.commercemarket.common.responsedto.PageResponseDto;
 import flab.commercemarket.controller.product.dto.ProductDto;
 import flab.commercemarket.controller.product.dto.ProductResponseDto;
 import flab.commercemarket.domain.product.ProductService;
@@ -40,20 +41,38 @@ public class ProductController {
     }
 
     @GetMapping
-    public List<ProductResponseDto> getProducts(@RequestParam int page) {
-        List<Product> products = productService.findProducts(page);
+    public PageResponseDto<ProductResponseDto> getProducts(@RequestParam int page, @RequestParam int size) {
+        List<Product> products = productService.findProducts(page, size);
 
-        return products.stream()
+        int totalElements = productService.countGetProduct();
+        List<ProductResponseDto> productResponseDto = products.stream()
                 .map(Product::toProductResponseDto)
                 .collect(Collectors.toList());
+
+        return PageResponseDto.<ProductResponseDto>builder()
+                .page(page)
+                .size(size)
+                .totalElements(totalElements)
+                .content(productResponseDto)
+                .build();
     }
 
     @GetMapping("/search")
-    public List<ProductResponseDto> searchProduct(@RequestParam String keyword) {
-        List<Product> products = productService.searchProduct(keyword);
-        return products.stream()
+    public PageResponseDto<ProductResponseDto> searchProduct(@RequestParam String keyword, @RequestParam int page, @RequestParam int size) {
+        // todo pagination 기능 추가
+        List<Product> products = productService.searchProduct(keyword, page, size);
+
+        int totalElements = productService.countSearchProductByKeyword(keyword);
+        List<ProductResponseDto> productResponseDto = products.stream()
                 .map(Product::toProductResponseDto)
                 .collect(Collectors.toList());
+
+        return PageResponseDto.<ProductResponseDto>builder()
+                .page(page)
+                .size(size)
+                .totalElements(totalElements)
+                .content(productResponseDto)
+                .build();
     }
 
     @DeleteMapping("/{productId}")

--- a/src/main/java/flab/commercemarket/controller/product/dto/ProductDto.java
+++ b/src/main/java/flab/commercemarket/controller/product/dto/ProductDto.java
@@ -4,11 +4,9 @@ import flab.commercemarket.domain.product.vo.Product;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 
 @Getter
-@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 public class ProductDto {

--- a/src/main/java/flab/commercemarket/domain/cart/mapper/CartMapper.java
+++ b/src/main/java/flab/commercemarket/domain/cart/mapper/CartMapper.java
@@ -15,10 +15,11 @@ public interface CartMapper {
 
     Optional<Cart> findById(long cartId);
 
-    boolean checkCartExistence(long userId, long productId);
-
     List<Cart> findAll(long userId);
 
     void deleteCart(long cartId);
 
+    boolean isAlreadyExistentProductInUserCart(long userId, long productId);
+
+    boolean isExistentProduct(long productId);
 }

--- a/src/main/java/flab/commercemarket/domain/product/ProductService.java
+++ b/src/main/java/flab/commercemarket/domain/product/ProductService.java
@@ -47,38 +47,45 @@ public class ProductService {
         return foundProduct;
     }
 
-
     public Product findProduct(long id) {
         log.info("Find ProductId. {}", id);
 
         return getVerifiedProduct(id);
     }
 
-    public List<Product> findProducts(int page) {
-        int size = 10;
+    public List<Product> findProducts(int page, int size) {
+        log.info("Find All Product. page = {}, size = {}", page, size);
+        int limit = size;
         int offset = (page - 1) * size;
 
-        log.info("Find All Product. page = {}", page);
-        return productMapper.findAll(offset, size);
+        return productMapper.findAll(offset, limit);
     }
 
-    public List<Product> searchProduct(String keyword) {
-        log.info("Search Product with keyword. keyword = {}", keyword);
-        return productMapper.searchProduct(keyword);
+    public int countGetProduct() {
+        log.info("Start getProductCount");
+
+        return productMapper.countProduct();
+    }
+
+    public List<Product> searchProduct(String keyword, int page, int size) {
+        log.info("Start searchProduct with keyword. keyword = {}", keyword);
+
+        int limit = size;
+        int offset = (page -1) * size;
+
+        return productMapper.searchProduct(keyword, offset, limit);
+    }
+
+    public int countSearchProductByKeyword(String keyword) {
+        log.info("Start countSearchProductByKeyword. keyword = {}", keyword);
+
+        return productMapper.searchProductCountByKeyword(keyword);
     }
 
     public void deleteProduct(long id) {
-        getVerifiedProduct(id);
-        productMapper.deleteProduct(id);
+        Product foundProduct = getVerifiedProduct(id);
+        productMapper.deleteProduct(foundProduct.getId());
         log.info("Delete Product. ProductId = {}", id);
-    }
-
-    public Product getVerifiedProduct(long id) {
-        Optional<Product> optionalProduct = productMapper.findById(id);
-        return optionalProduct.orElseThrow(() -> {
-            log.info("productId = {}", id);
-            return new DataNotFoundException("조회한 상품 정보가 없음");
-        });
     }
 
     public void updateLikeCount(long productId) {
@@ -93,5 +100,13 @@ public class ProductService {
         productMapper.updateLikeCount(product);
 
         log.info("New LikeCount = {}", newLikeCount);
+    }
+
+    private Product getVerifiedProduct(long id) {
+        Optional<Product> optionalProduct = productMapper.findById(id);
+        return optionalProduct.orElseThrow(() -> {
+            log.info("productId = {}", id);
+            return new DataNotFoundException("조회한 상품 정보가 없음");
+        });
     }
 }

--- a/src/main/java/flab/commercemarket/domain/product/mapper/ProductMapper.java
+++ b/src/main/java/flab/commercemarket/domain/product/mapper/ProductMapper.java
@@ -17,9 +17,13 @@ public interface ProductMapper {
 
     Optional<Product> findById(long id);
 
-    List<Product> findAll(int offset, int size);
+    List<Product> findAll(int offset, int limit);
 
-    List<Product> searchProduct(String keyword);
+    int countProduct();
+
+    List<Product> searchProduct(String keyword, int offset, int limit);
+
+    int searchProductCountByKeyword(String keyword);
 
     void deleteProduct(long id);
 

--- a/src/main/java/flab/commercemarket/domain/product/vo/Product.java
+++ b/src/main/java/flab/commercemarket/domain/product/vo/Product.java
@@ -17,7 +17,6 @@ public class Product {
     private int stockAmount;
     private int salesAmount;
     private int likeCount;
-    private int dislikeCount;
     private long sellerId;
 
     public ProductResponseDto toProductResponseDto() {
@@ -30,7 +29,6 @@ public class Product {
                 .stockAmount(stockAmount)
                 .salesAmount(salesAmount)
                 .likeCount(likeCount)
-                .dislikeCount(dislikeCount)
                 .build();
     }
 }

--- a/src/main/resources/mybatis/cart-mapper.xml
+++ b/src/main/resources/mybatis/cart-mapper.xml
@@ -36,11 +36,16 @@
         DELETE FROM cart WHERE id = #{id}
     </delete>
 
-
-    <select id="checkCartExistence" resultType="boolean">
+    <select id="isAlreadyExistentProductInUserCart" resultType="boolean">
         SELECT EXISTS(
-                       SELECT 1 FROM cart
-                       WHERE user_id = #{userId} AND product_id = #{productId}
-                   ) AS exist
+            SELECT 1 FROM cart
+            WHERE user_id = #{userId} AND product_id = #{productId}
+        ) AS exist
+    </select>
+
+    <select id="isExistentProduct" resultType="boolean">
+        SELECT EXISTS(
+            SELECT 1 FROM product WHERE id = #{productId}
+        ) AS exist
     </select>
 </mapper>

--- a/src/main/resources/mybatis/product-mapper.xml
+++ b/src/main/resources/mybatis/product-mapper.xml
@@ -3,7 +3,15 @@
 <mapper namespace="flab.commercemarket.domain.product.mapper.ProductMapper">
 
     <resultMap id="productResultMap" type="flab.commercemarket.domain.product.vo.Product">
-        <result column="product_name" property="name"/>
+        <id property="id" column="id"/>
+        <result property="name" column="product_name"/>
+        <result property="price" column="price"/>
+        <result property="imageUrl" column="image_url"/>
+        <result property="description" column="description"/>
+        <result property="stockAmount" column="stock_amount"/>
+        <result property="salesAmount" column="sales_amount"/>
+        <result property="likeCount" column="like_count"/>
+        <result property="sellerId" column="seller_id"/>
     </resultMap>
 
     <insert id="insertProduct" parameterType="flab.commercemarket.domain.product.vo.Product" useGeneratedKeys="true"
@@ -29,11 +37,21 @@
     </select>
 
     <select id="findAll" parameterType="map" resultMap="productResultMap">
-        SELECT * FROM product LIMIT #{offset, jdbcType=INTEGER}, #{size, jdbcType=INTEGER}
+        SELECT * FROM product LIMIT #{offset}, #{size}
     </select>
 
-    <select id="searchProduct" parameterType="String" resultMap="productResultMap">
-        SELECT * FROM product WHERE product_name LIKE CONCAT('%', #{keyword}, '%')
+    <select id="countProduct" resultType="int">
+        SELECT COUNT(*) FROM product
+    </select>
+
+    <select id="searchProduct" resultMap="productResultMap">
+        SELECT * FROM product
+        WHERE product_name LIKE CONCAT('%', #{keyword}, '%')
+        LIMIT #{offset}, #{size}
+    </select>
+
+    <select id="searchProductCountByKeyword" resultType="int">
+        SELECT COUNT(*) FROM product WHERE product_name LIKE CONCAT('%', #{keyword}, '%')
     </select>
 
     <delete id="deleteProduct" parameterType="long">

--- a/src/test/java/flab/commercemarket/product/controller/ProductControllerTest.java
+++ b/src/test/java/flab/commercemarket/product/controller/ProductControllerTest.java
@@ -119,6 +119,7 @@ class ProductControllerTest {
     @Test
     void getProductsTest() throws Exception {
         int page = 1;
+        int size = 10;
         Product product1 = makeProductFixture(1);
         Product product2 = makeProductFixture(2);
 
@@ -126,53 +127,66 @@ class ProductControllerTest {
                 product1, product2
         );
 
-        when(productService.findProducts(page)).thenReturn(expectedProducts);
+        when(productService.findProducts(page, size)).thenReturn(expectedProducts);
+        when(productService.countGetProduct()).thenReturn(2);
 
         mockMvc.perform(get("/products")
-                        .param("page", String.valueOf(page))
+                        .param("page",  String.valueOf(page))
+                        .param("size", String.valueOf(size))
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.length()").value(expectedProducts.size()))
-                .andExpect(jsonPath("$[0].id").value(product1.getId()))
-                .andExpect(jsonPath("$[0].name").value(product1.getName()))
-                .andExpect(jsonPath("$[0].price").value(product1.getPrice()))
-                .andExpect(jsonPath("$[0].imageUrl").value(product1.getImageUrl()))
-                .andExpect(jsonPath("$[0].description").value(product1.getDescription()))
-                .andExpect(jsonPath("$[0].stockAmount").value(product1.getStockAmount()))
-                .andExpect(jsonPath("$[1].id").value(product2.getId()))
-                .andExpect(jsonPath("$[1].name").value(product2.getName()))
-                .andExpect(jsonPath("$[1].price").value(product2.getPrice()))
-                .andExpect(jsonPath("$[1].imageUrl").value(product2.getImageUrl()))
-                .andExpect(jsonPath("$[1].description").value(product2.getDescription()))
-                .andExpect(jsonPath("$[1].stockAmount").value(product2.getStockAmount()));
+                .andExpect(jsonPath("$.content.length()").value(expectedProducts.size()))
+                .andExpect(jsonPath("$.content[0].id").value(product1.getId()))
+                .andExpect(jsonPath("$.content[0].name").value(product1.getName()))
+                .andExpect(jsonPath("$.content[0].price").value(product1.getPrice()))
+                .andExpect(jsonPath("$.content[0].imageUrl").value(product1.getImageUrl()))
+                .andExpect(jsonPath("$.content[0].description").value(product1.getDescription()))
+                .andExpect(jsonPath("$.content[0].stockAmount").value(product1.getStockAmount()))
+                .andExpect(jsonPath("$.content[1].id").value(product2.getId()))
+                .andExpect(jsonPath("$.content[1].name").value(product2.getName()))
+                .andExpect(jsonPath("$.content[1].price").value(product2.getPrice()))
+                .andExpect(jsonPath("$.content[1].imageUrl").value(product2.getImageUrl()))
+                .andExpect(jsonPath("$.content[1].description").value(product2.getDescription()))
+                .andExpect(jsonPath("$.content[1].stockAmount").value(product2.getStockAmount()))
+                .andExpect(jsonPath("$.page").value(page))
+                .andExpect(jsonPath("$.size").value(size))
+                .andExpect(jsonPath("$.totalElements").value(expectedProducts.size()));
     }
 
     @Test
     void searchProductTest() throws Exception {
         String keyword = "product";
+        int size = 10;
+        int page = 1;
         Product product1 = makeProductFixture(1);
         Product product2 = makeProductFixture(2);
 
         List<Product> expectedProducts = Arrays.asList(product1, product2);
 
-        when(productService.searchProduct(keyword)).thenReturn(expectedProducts);
+        when(productService.searchProduct(keyword, page, size)).thenReturn(expectedProducts);
+        when(productService.countSearchProductByKeyword(keyword)).thenReturn(2);
 
         mockMvc.perform(get("/products/search")
-                        .param("keyword", keyword))
+                        .param("keyword", keyword)
+                        .param("page", String.valueOf(page))
+                        .param("size", String.valueOf(size)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.length()").value(expectedProducts.size()))
-                .andExpect(jsonPath("$[0].id").value(product1.getId()))
-                .andExpect(jsonPath("$[0].name").value(product1.getName()))
-                .andExpect(jsonPath("$[0].price").value(product1.getPrice()))
-                .andExpect(jsonPath("$[0].imageUrl").value(product1.getImageUrl()))
-                .andExpect(jsonPath("$[0].description").value(product1.getDescription()))
-                .andExpect(jsonPath("$[0].stockAmount").value(product1.getStockAmount()))
-                .andExpect(jsonPath("$[1].id").value(product2.getId()))
-                .andExpect(jsonPath("$[1].name").value(product2.getName()))
-                .andExpect(jsonPath("$[1].price").value(product2.getPrice()))
-                .andExpect(jsonPath("$[1].imageUrl").value(product2.getImageUrl()))
-                .andExpect(jsonPath("$[1].description").value(product2.getDescription()))
-                .andExpect(jsonPath("$[1].stockAmount").value(product2.getStockAmount()));
+                .andExpect(jsonPath("$.content.length()").value(expectedProducts.size()))
+                .andExpect(jsonPath("$.content[0].id").value(product1.getId()))
+                .andExpect(jsonPath("$.content[0].name").value(product1.getName()))
+                .andExpect(jsonPath("$.content[0].price").value(product1.getPrice()))
+                .andExpect(jsonPath("$.content[0].imageUrl").value(product1.getImageUrl()))
+                .andExpect(jsonPath("$.content[0].description").value(product1.getDescription()))
+                .andExpect(jsonPath("$.content[0].stockAmount").value(product1.getStockAmount()))
+                .andExpect(jsonPath("$.content[1].id").value(product2.getId()))
+                .andExpect(jsonPath("$.content[1].name").value(product2.getName()))
+                .andExpect(jsonPath("$.content[1].price").value(product2.getPrice()))
+                .andExpect(jsonPath("$.content[1].imageUrl").value(product2.getImageUrl()))
+                .andExpect(jsonPath("$.content[1].description").value(product2.getDescription()))
+                .andExpect(jsonPath("$.content[1].stockAmount").value(product2.getStockAmount()))
+                .andExpect(jsonPath("$.page").value(page))
+                .andExpect(jsonPath("$.size").value(size))
+                .andExpect(jsonPath("$.totalElements").value(2));
     }
 
     @Test
@@ -186,13 +200,13 @@ class ProductControllerTest {
     }
 
     private ProductDto makeProductDtoFixture(int param) {
-        ProductDto productDto = new ProductDto();
-        productDto.setName("name " + param);
-        productDto.setPrice(param * 1000);
-        productDto.setImageUrl("url " + param);
-        productDto.setDescription("description " + param);
-        productDto.setStockAmount(param * 10);
-        return productDto;
+        String name = "name " + param;
+        int price = param * 1000;
+        String url = "url " + param;
+        String description = "description " + param;
+        int stockAmount = param * 10;
+
+        return new ProductDto(name, price, url, description, stockAmount);
     }
 
     private Product makeProductFixture(int param) {

--- a/src/test/java/flab/commercemarket/product/mapper/ProductMapperTest.java
+++ b/src/test/java/flab/commercemarket/product/mapper/ProductMapperTest.java
@@ -37,7 +37,6 @@ class ProductMapperTest {
         product.setStockAmount(1);
         product.setSalesAmount(1);
         product.setLikeCount(1);
-        product.setDislikeCount(1);
         product.setSellerId(2);
 
         // when
@@ -126,6 +125,8 @@ class ProductMapperTest {
     @Test
     @DisplayName("키워드에 해당하는 상품을 검색하여 반환합니다")
     void searchProduct() {
+        int offset = 1;
+        int size = 10;
         Product product1 = new Product();
         product1.setName("Apple");
         product1.setPrice(1000);
@@ -144,7 +145,7 @@ class ProductMapperTest {
 
         String keyword = "Apple";
 
-        List<Product> searchResults = productMapper.searchProduct(keyword);
+        List<Product> searchResults = productMapper.searchProduct(keyword, offset, size);
 
         assertNotNull(searchResults);
 
@@ -169,7 +170,6 @@ class ProductMapperTest {
         product.setStockAmount(1);
         product.setSalesAmount(1);
         product.setLikeCount(1);
-        product.setDislikeCount(1);
         product.setSellerId(2);
 
         // 상품을 데이터베이스에 삽입

--- a/src/test/java/flab/commercemarket/product/service/ProductServiceTest.java
+++ b/src/test/java/flab/commercemarket/product/service/ProductServiceTest.java
@@ -72,8 +72,6 @@ class ProductServiceTest {
         assertThat(updatedProductData.getDescription()).isEqualTo(updateProduct.getDescription());
         assertThat(updatedProductData.getStockAmount()).isEqualTo(updateProduct.getStockAmount());
 
-        verify(productMapper).updateProduct(updateProduct);
-        verify(productMapper).findById(productId);
     }
 
     @Test
@@ -84,8 +82,8 @@ class ProductServiceTest {
         Product updatedProductData = makeProductFixture(1);
 
         // when
-        // productMapper.findById()가 호출될 때 동작 설정
-        when(productMapper.findById(productId)).thenReturn(Optional.empty());
+        when(productMapper.findById(productId)).thenThrow(DataNotFoundException.class);
+
 
         // then
         assertThrows(DataNotFoundException.class, () -> {
@@ -94,32 +92,115 @@ class ProductServiceTest {
     }
 
     @Test
-    public void searchProductTest() throws Exception {
+    @DisplayName("ProductId로 상품을 조회한다.")
+    public void findProductTest() throws Exception {
+        // given
+        long productId = 1L;
+        Product product = makeProductFixture((int)productId);
+
+        // when
+        when(productMapper.findById(productId)).thenReturn(Optional.of(product));
+
+        Product foundProduct = productService.findProduct(productId);
+
+        // then
+        assertThat(product).isEqualTo(foundProduct);
+    }
+
+    @Test
+    @DisplayName("상품 목록을 전체 조회하면 페이지네이션이 적용되어야 한다.")
+    public void findProductsTest() throws Exception {
+        // given
+        int page = 2;
+        int size = 3;
+        Product product1 = makeProductFixture(1);
+        Product product2 = makeProductFixture(2);
+        Product product3 = makeProductFixture(3);
+        Product product4 = makeProductFixture(4);
+
+        List<Product> expectedResults = Arrays.asList(product4);
+
+        // when
+        int offset = (page - 1) * size;
+        when(productMapper.findAll(offset, size)).thenReturn(expectedResults);
+        List<Product> foundProducts = productService.findProducts(page, size);
+
+        // then
+        assertThat(expectedResults).isEqualTo(foundProducts);
+
+    }
+
+    @Test
+    @DisplayName("상품 목록의 전체 개수를 반환한다.")
+    public void getProductCountTest() throws Exception {
         // given
         Product product1 = makeProductFixture(1);
         Product product2 = makeProductFixture(2);
         Product product3 = makeProductFixture(3);
         Product product4 = makeProductFixture(4);
 
-        List<Product> expectedResults = Arrays.asList(product1,product2,product3);
+        List<Product> expectedResults = Arrays.asList(product1, product2, product3, product4);
 
         // when
-        when(productMapper.searchProduct("product")).thenReturn(expectedResults);
+        when(productMapper.countProduct()).thenReturn(expectedResults.size());
+        int result = productService.countGetProduct();
 
         // then
-        List<Product> actualResults = productService.searchProduct("product");
+        assertThat(expectedResults.size()).isEqualTo(result);
+    }
+
+    @Test
+    @DisplayName("키워드 조회 기능에 페이지네이션이 적용 되어야한다.")
+    public void searchProductTest() throws Exception {
+        // given
+        int page = 1;
+        int size = 3;
+
+        Product product1 = makeProductFixture(1);
+        Product product2 = makeProductFixture(2);
+        Product product3 = makeProductFixture(3);
+        Product product4 = makeProductFixture(4);
+
+        List<Product> expectedResults = Arrays.asList(product1, product2, product3);
+
+        // when
+        int offset = (page - 1) * size;
+        when(productMapper.searchProduct("product", offset, size)).thenReturn(expectedResults);
+
+        // then
+        List<Product> actualResults = productService.searchProduct("product", page, size);
         assertThat(actualResults).isEqualTo(expectedResults);
+    }
+
+    @Test
+    @DisplayName("특정 키워드로 조회한 데이터의 전체 개수를 반환한다.")
+    public void searchProductCountByKeywordTest() throws Exception {
+        // given
+        String keyword = "computer";
+        Product product1 = makeProductFixture(1);
+        Product product2 = makeProductFixture(2);
+        Product product3 = makeProductFixture(3);
+        Product product4 = makeProductFixture(4);
+
+        List<Product> expectedResults = Arrays.asList(product1, product2, product3, product4);
+
+        // when
+        when(productMapper.searchProductCountByKeyword(keyword)).thenReturn(expectedResults.size());
+        int result = productService.countSearchProductByKeyword(keyword);
+
+        // then
+        assertThat(expectedResults.size()).isEqualTo(result);
     }
 
     @Test
     public void deleteProductTest() throws Exception {
         // given
-        long productId = 1;
-        Product existProduct = makeProductFixture(1);
+        long productId = 1L;
+        Product product = makeProductFixture((int) productId);
+        when(productMapper.findById(productId)).thenReturn(Optional.of(product));
 
         // when
-        when(productMapper.findById(productId)).thenReturn(Optional.of(existProduct));
-        productService.deleteProduct(productId);
+        productService.deleteProduct(product.getId());
 
         // then
         verify(productMapper).deleteProduct(productId);
@@ -135,6 +216,7 @@ class ProductServiceTest {
 
 
         when(productMapper.findById(productId)).thenReturn(Optional.of(product));
+
         productService.updateLikeCount(productId);
 
         assertThat(11).isEqualTo(product.getLikeCount());
@@ -142,6 +224,7 @@ class ProductServiceTest {
 
     private Product makeProductFixture(int param) {
         Product product = new Product();
+        product.setId((long) param);
         product.setName("name"+param);
         product.setPrice(param*1000);
         product.setImageUrl("url" + param);


### PR DESCRIPTION
## Product 페이지네이션 적용

### 목적
제품 목록과 키워드 검색 기능에 페이지네이션을 적용하여 조회 쿼리의 부하를 줄이고, 사용자 경험을 향상시킬 수 있습니다.

### 내용
- 제품 목록 조회기능에 던져지는 파라미터를 수정했습니다.
- 응답값도 조회된 List 만 던지지않고 `page`, `size`, `totalElements`가 던져지도록 수정했습니다.
- 키워드 검색 기능에 페이지네이션 기능을 추가했습니다.

### 영향
- 모든 데이터를 한 번에 표시하지 않고 페이지네이션을 사용하여 사용자 경험이 향상될것입니다.
- 많은 양의 데이터를 한 번에 로딩하지 않기 때문에 네트워크 부하가 줄어들 것입니다.

### 관련 이슈
#34 

### 참고 사항
- 해당 PR에서 Product 검증 로직을 `helper` 클래스로 위임하였습니다.
- 해당 PR을 merge 할때 rebase가 필요합니다.

### 질문 사항
컨트롤러 단위 테스트 삭제하는것에 대해 의견을 여쭙고 싶습니다. 
컨트롤러에 파라메터로 던져지는 정보와 반환되는 응답값을 검증하고있습니다.
그런데 스프링에서 이미 검증된 기능을 테스트하는 것에 대한 의문이 생겼습니다.🥲 
RestDocs를 사용할것이 아니라면, 현재 작성된 컨트롤러에 대한 테스트를 삭제하는 것에 대한 의견을 여쭤보고싶습니다!(다른 PR에서도 컨트롤러에 대한 테스트케이스를 작성하지 않고 있습니다.)