### PR TITLE
Feature/18-refactor-product

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 tasks.named('test') {

--- a/src/main/java/flab/commercemarket/controller/cart/CartController.java
+++ b/src/main/java/flab/commercemarket/controller/cart/CartController.java
@@ -45,7 +45,7 @@ public class CartController {
     @GetMapping
     public List<CartResponseDto> getCarts(@RequestParam long userId) {
         // todo 로그인 기능 추가 이후 userId를 조회하는 로직 변경 -> 토큰에서 조회 등
-        List<Cart> carts = cartService.getCarts(userId);
+        List<Cart> carts = cartService.findCarts(userId);
         return carts.stream()
                 .map(Cart::toCartResponseDto)
                 .collect(Collectors.toList());

--- a/src/main/java/flab/commercemarket/controller/product/ProductController.java
+++ b/src/main/java/flab/commercemarket/controller/product/ProductController.java
@@ -6,6 +6,7 @@ import flab.commercemarket.controller.product.dto.ProductResponseDto;
 import flab.commercemarket.domain.product.ProductService;
 import flab.commercemarket.domain.product.vo.Product;
 import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -27,7 +28,7 @@ public class ProductController {
 
     @PatchMapping("/{productId}")
     public ProductResponseDto patchProduct(@PathVariable("productId") long productId,
-                                           @RequestBody ProductDto productDto) {
+                                           @RequestBody @Validated ProductDto productDto) {
         Product product = productDto.toProduct();
         Product updateProduct = productService.updateProduct(productId, product);
 
@@ -59,7 +60,6 @@ public class ProductController {
 
     @GetMapping("/search")
     public PageResponseDto<ProductResponseDto> searchProduct(@RequestParam String keyword, @RequestParam int page, @RequestParam int size) {
-        // todo pagination 기능 추가
         List<Product> products = productService.searchProduct(keyword, page, size);
 
         int totalElements = productService.countSearchProductByKeyword(keyword);

--- a/src/main/java/flab/commercemarket/controller/product/ProductController.java
+++ b/src/main/java/flab/commercemarket/controller/product/ProductController.java
@@ -36,7 +36,7 @@ public class ProductController {
 
     @GetMapping("/{productId}")
     public ProductResponseDto getProduct(@PathVariable("productId") long productId) {
-        Product product = productService.findProduct(productId);
+        Product product = productService.getProduct(productId);
         return product.toProductResponseDto();
     }
 

--- a/src/main/java/flab/commercemarket/controller/product/ProductController.java
+++ b/src/main/java/flab/commercemarket/controller/product/ProductController.java
@@ -76,8 +76,8 @@ public class ProductController {
     }
 
     @DeleteMapping("/{productId}")
-    public void deleteProduct(@PathVariable("productId") long productId) {
-        productService.deleteProduct(productId);
+    public void deleteProduct(@PathVariable("productId") long productId, @RequestParam long loginUserId) {
+        productService.deleteProduct(productId, loginUserId);
     }
 
     @PostMapping("/{productId}/likes")

--- a/src/main/java/flab/commercemarket/controller/product/dto/ProductDto.java
+++ b/src/main/java/flab/commercemarket/controller/product/dto/ProductDto.java
@@ -5,16 +5,33 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Positive;
+
 
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 public class ProductDto {
+
+    @NotNull(message = "Name cannot be null")
     private String name;
+
+    @Min(value = 0, message = "Price cannot be negative")
     private int price;
+
+    @NotNull(message = "Image URL cannot be null")
     private String imageUrl;
+
+    @NotNull(message = "Description cannot be null")
     private String description;
+
+    @Min(value = 0, message = "Stock amount cannot be negative")
     private int stockAmount;
+
+    @Positive(message = "Seller ID must be a positive value")
+    private long sellerId;
 
     public Product toProduct() {
         return Product.builder()
@@ -23,6 +40,7 @@ public class ProductDto {
                 .imageUrl(imageUrl)
                 .description(description)
                 .stockAmount(stockAmount)
+                .sellerId(sellerId)
                 .build();
     }
 }

--- a/src/main/java/flab/commercemarket/controller/wishlist/WishListController.java
+++ b/src/main/java/flab/commercemarket/controller/wishlist/WishListController.java
@@ -28,8 +28,8 @@ public class WishListController {
                                         @RequestParam int page,
                                         @RequestParam int size) {
         // TODO @RequestParam long userId 제거 -> 로그인 정보에서 userId 가져오도록 refactoring
-        List<WishList> wishLists = wishListService.getWishLists(userId, page, size);
-        int totalElements = wishListService.getWishListCountByUserId(userId);
+        List<WishList> wishLists = wishListService.findWishLists(userId, page, size);
+        int totalElements = wishListService.findWishListCountByUserId(userId);
 
         List<WishListResponseDto> wishListResponseList = wishLists.stream()
                 .map(WishList::toWishlistResponseDto)

--- a/src/main/java/flab/commercemarket/domain/cart/CartService.java
+++ b/src/main/java/flab/commercemarket/domain/cart/CartService.java
@@ -36,7 +36,7 @@ public class CartService {
     public Cart updateCart(Cart data, long cartId, long userId) {
         log.info("Start updateCart");
 
-        Cart foundCart = getVerifiedCart(cartId);
+        Cart foundCart = getCart(cartId);
         authorizationHelper.checkUserAuthorization(foundCart.getUserId(), userId);
 
         // userID와 productId는 수정되면 안된다.
@@ -49,7 +49,7 @@ public class CartService {
         return foundCart;
     }
 
-    public List<Cart> getCarts(long userId) {
+    public List<Cart> findCarts(long userId) {
         log.info("Start getCarts");
 
         // todo 페이지네이션 적용해야 합니다.
@@ -60,7 +60,7 @@ public class CartService {
     public void deleteCart(long cartId, long userId) {
         log.info("Start deleteCart");
 
-        Cart cart = getVerifiedCart(cartId);
+        Cart cart = getCart(cartId);
         authorizationHelper.checkUserAuthorization(cart.getUserId(), userId);
 
         cartMapper.deleteCart(cartId);
@@ -70,7 +70,7 @@ public class CartService {
     public int calculateTotalPrice(long userId) {
         log.info("Start calculateTotalPrice");
 
-        List<Cart> carts = getCarts(userId);
+        List<Cart> carts = findCarts(userId);
 
         int sum = 0;
         // 성능이슈 예상지점
@@ -79,7 +79,7 @@ public class CartService {
         for (Cart cart : carts) {
             int quantity = cart.getQuantity();
             long productId = cart.getProductId();
-            int price = productService.findProduct(productId).getPrice();
+            int price = productService.getProduct(productId).getPrice();
             sum += quantity * price;
         }
 
@@ -87,7 +87,7 @@ public class CartService {
         return sum;
     }
 
-    private Cart getVerifiedCart(long cartId) {
+    private Cart getCart(long cartId) {
         Optional<Cart> optionalCart = cartMapper.findById(cartId);
         return optionalCart.orElseThrow(() -> {
             log.info("cartId = {}", cartId);

--- a/src/main/java/flab/commercemarket/domain/product/ProductService.java
+++ b/src/main/java/flab/commercemarket/domain/product/ProductService.java
@@ -1,6 +1,7 @@
 package flab.commercemarket.domain.product;
 
 import flab.commercemarket.common.exception.DataNotFoundException;
+import flab.commercemarket.common.helper.AuthorizationHelper;
 import flab.commercemarket.domain.product.mapper.ProductMapper;
 import flab.commercemarket.domain.product.vo.Product;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +18,7 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class ProductService {
 
+    private final AuthorizationHelper authorizationHelper;
     private final ProductMapper productMapper;
 
     public Product registerProduct(Product product) {
@@ -32,9 +34,10 @@ public class ProductService {
     public Product updateProduct(long productId, Product data) {
         log.info("Start updateProduct");
 
-        // todo 요청으로 넘어오는 data에 null 값이 없는지 체크하는 로직이 필요합니다.
-
         Product foundProduct = getProduct(productId);
+
+        authorizationHelper.checkUserAuthorization(foundProduct.getSellerId(), data.getSellerId());
+
         foundProduct.setName(data.getName());
         foundProduct.setPrice(data.getPrice());
         foundProduct.setImageUrl(data.getImageUrl());

--- a/src/main/java/flab/commercemarket/domain/product/ProductService.java
+++ b/src/main/java/flab/commercemarket/domain/product/ProductService.java
@@ -29,12 +29,12 @@ public class ProductService {
         return product;
     }
 
-    public Product updateProduct(long id, Product data) {
+    public Product updateProduct(long productId, Product data) {
         log.info("Start updateProduct");
 
         // todo 요청으로 넘어오는 data에 null 값이 없는지 체크하는 로직이 필요합니다.
 
-        Product foundProduct = getVerifiedProduct(id);
+        Product foundProduct = getProduct(productId);
         foundProduct.setName(data.getName());
         foundProduct.setPrice(data.getPrice());
         foundProduct.setImageUrl(data.getImageUrl());
@@ -43,14 +43,18 @@ public class ProductService {
 
         productMapper.updateProduct(foundProduct);
 
-        log.info("Update Product. productId = {}", id);
+        log.info("Update Product. productId = {}", productId);
         return foundProduct;
     }
 
-    public Product findProduct(long id) {
-        log.info("Find ProductId. {}", id);
+    public Product getProduct(long productId) {
+        log.info("Start get ProductId: {}", productId);
 
-        return getVerifiedProduct(id);
+        Optional<Product> optionalProduct = productMapper.findById(productId);
+        return optionalProduct.orElseThrow(() -> {
+            log.info("productId = {}", productId);
+            return new DataNotFoundException("조회한 상품 정보가 없음");
+        });
     }
 
     public List<Product> findProducts(int page, int size) {
@@ -82,15 +86,15 @@ public class ProductService {
         return productMapper.searchProductCountByKeyword(keyword);
     }
 
-    public void deleteProduct(long id) {
-        Product foundProduct = getVerifiedProduct(id);
+    public void deleteProduct(long productId) {
+        Product foundProduct = getProduct(productId);
         productMapper.deleteProduct(foundProduct.getId());
-        log.info("Delete Product. ProductId = {}", id);
+        log.info("Delete Product. ProductId = {}", productId);
     }
 
     public void updateLikeCount(long productId) {
         log.info("Start increaseLikeCount");
-        Product product = findProduct(productId);
+        Product product = getProduct(productId);
         // todo 로그인된 유저가 상품을 구매했는지 검증하는 로직이 필요함
 
         int likeCount = product.getLikeCount();
@@ -100,13 +104,5 @@ public class ProductService {
         productMapper.updateLikeCount(product);
 
         log.info("New LikeCount = {}", newLikeCount);
-    }
-
-    private Product getVerifiedProduct(long id) {
-        Optional<Product> optionalProduct = productMapper.findById(id);
-        return optionalProduct.orElseThrow(() -> {
-            log.info("productId = {}", id);
-            return new DataNotFoundException("조회한 상품 정보가 없음");
-        });
     }
 }

--- a/src/main/java/flab/commercemarket/domain/product/ProductService.java
+++ b/src/main/java/flab/commercemarket/domain/product/ProductService.java
@@ -86,8 +86,11 @@ public class ProductService {
         return productMapper.searchProductCountByKeyword(keyword);
     }
 
-    public void deleteProduct(long productId) {
+    public void deleteProduct(long productId, long loginUserId) {
         Product foundProduct = getProduct(productId);
+
+        authorizationHelper.checkUserAuthorization(foundProduct.getSellerId(), loginUserId);
+
         productMapper.deleteProduct(foundProduct.getId());
         log.info("Delete Product. ProductId = {}", productId);
     }

--- a/src/main/java/flab/commercemarket/domain/product/vo/Product.java
+++ b/src/main/java/flab/commercemarket/domain/product/vo/Product.java
@@ -29,6 +29,7 @@ public class Product {
                 .stockAmount(stockAmount)
                 .salesAmount(salesAmount)
                 .likeCount(likeCount)
+                .sellerId(sellerId)
                 .build();
     }
 }

--- a/src/main/java/flab/commercemarket/domain/wishlist/WishListService.java
+++ b/src/main/java/flab/commercemarket/domain/wishlist/WishListService.java
@@ -3,8 +3,6 @@ package flab.commercemarket.domain.wishlist;
 import flab.commercemarket.common.exception.DataNotFoundException;
 import flab.commercemarket.common.exception.DuplicateDataException;
 import flab.commercemarket.common.helper.AuthorizationHelper;
-import flab.commercemarket.domain.product.ProductService;
-import flab.commercemarket.domain.user.UserService;
 import flab.commercemarket.domain.wishlist.mapper.WishListMapper;
 import flab.commercemarket.domain.wishlist.vo.WishList;
 import lombok.RequiredArgsConstructor;
@@ -25,13 +23,12 @@ public class WishListService {
     private final ProductService productService;
     private final AuthorizationHelper authorizationHelper;
 
-
     @Transactional
     public void registerWishList(long userId, long productId) {
         log.info("Start registerWishList");
 
         userService.getUserById(userId);
-        productService.findProduct(productId);
+        productService.getProduct(productId);
         verifyDuplicatedWishList(userId, productId);
 
         wishListMapper.insertWishList(userId, productId);
@@ -39,7 +36,7 @@ public class WishListService {
     }
 
     @Transactional(readOnly = true)
-    public List<WishList> getWishLists(long userId, int page, int size) {
+    public List<WishList> findWishLists(long userId, int page, int size) {
         log.info("Start registerWishList");
 
         int limit = size;
@@ -51,7 +48,7 @@ public class WishListService {
     }
 
     @Transactional(readOnly = true)
-    public int getWishListCountByUserId(long userId) {
+    public int findWishListCountByUserId(long userId) {
         log.info("Start getWishListCountByUserId = {}", userId);
 
         return wishListMapper.getWishListCountByUserId(userId);

--- a/src/main/java/flab/commercemarket/domain/wishlist/WishListService.java
+++ b/src/main/java/flab/commercemarket/domain/wishlist/WishListService.java
@@ -19,16 +19,14 @@ import java.util.Optional;
 public class WishListService {
 
     private final WishListMapper wishListMapper;
-    private final UserService userService;
-    private final ProductService productService;
     private final AuthorizationHelper authorizationHelper;
 
     @Transactional
     public void registerWishList(long userId, long productId) {
         log.info("Start registerWishList");
 
-        userService.getUserById(userId);
-        productService.getProduct(productId);
+        checkUserExistence(userId);
+        checkValidProduct(productId);
         verifyDuplicatedWishList(userId, productId);
 
         wishListMapper.insertWishList(userId, productId);
@@ -42,7 +40,7 @@ public class WishListService {
         int limit = size;
         int offset = (page - 1) * size;
 
-        userService.getUserById(userId);
+        checkUserExistence(userId);
         log.info("Get WishList userId = {}", userId);
         return wishListMapper.getWishListItemByUserIdWithPagination(userId, limit, offset);
     }
@@ -83,5 +81,24 @@ public class WishListService {
             log.warn("wishListId = {}", wishListId);
             return new DataNotFoundException("조회한 위시리스트가 없음");
         });
+    }
+
+    private void checkUserExistence(long userId) {
+        log.info("Check Existent User. userId: {}", userId);
+
+        boolean result = wishListMapper.isExistentUser(userId);
+        if (!result) {
+            log.warn("userId: {}", userId);
+            throw new DataNotFoundException("해당 사용자가 존재하지 않음");
+        }
+    }
+
+    private void checkValidProduct(long productId) {
+        log.info("Check Existent Product. productId: {}", productId);
+
+        if (!wishListMapper.isExistentProduct(productId)) {
+            log.info("productId = {}", productId);
+            throw new DataNotFoundException("존재하지 않는 상품");
+        }
     }
 }

--- a/src/main/java/flab/commercemarket/domain/wishlist/mapper/WishListMapper.java
+++ b/src/main/java/flab/commercemarket/domain/wishlist/mapper/WishListMapper.java
@@ -20,4 +20,8 @@ public interface WishListMapper {
     Optional<WishList> findById(long id);
 
     void deleteWishList(long wishListId);
+
+    boolean isExistentUser(long userId);
+
+    boolean isExistentProduct(long productId);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,3 @@
-# console color on
 spring:
-  output:
-    ansi:
-      enabled: always
+  profiles:
+    active: local

--- a/src/main/resources/mybatis/product-mapper.xml
+++ b/src/main/resources/mybatis/product-mapper.xml
@@ -37,7 +37,7 @@
     </select>
 
     <select id="findAll" parameterType="map" resultMap="productResultMap">
-        SELECT * FROM product LIMIT #{offset}, #{size}
+        SELECT * FROM product LIMIT #{offset}, #{limit}
     </select>
 
     <select id="countProduct" resultType="int">
@@ -47,7 +47,7 @@
     <select id="searchProduct" resultMap="productResultMap">
         SELECT * FROM product
         WHERE product_name LIKE CONCAT('%', #{keyword}, '%')
-        LIMIT #{offset}, #{size}
+        LIMIT #{offset}, #{limit}
     </select>
 
     <select id="searchProductCountByKeyword" resultType="int">

--- a/src/main/resources/mybatis/wishlist-mapper.xml
+++ b/src/main/resources/mybatis/wishlist-mapper.xml
@@ -35,4 +35,16 @@
     <delete id="deleteWishList" parameterType="long">
         DELETE FROM wish_list where id = #{id}
     </delete>
+
+    <select id="isExistentUser" resultType="boolean">
+        SELECT EXISTS(
+                       SELECT 1 FROM market_user WHERE id = #{userId}
+                   ) AS exist
+    </select>
+
+    <select id="isExistentProduct" resultType="boolean">
+        SELECT EXISTS(
+                       SELECT 1 FROM product WHERE id = #{productId}
+                   ) AS exist
+    </select>
 </mapper>

--- a/src/test/java/flab/commercemarket/cart/service/CartServiceTest.java
+++ b/src/test/java/flab/commercemarket/cart/service/CartServiceTest.java
@@ -204,8 +204,8 @@ class CartServiceTest {
                 new Cart(1L, 3L, 30)
         );
 
-        when(cartService.getCarts(userId)).thenReturn(expectedCartList);
-        List<Cart> result = cartService.getCarts(userId);
+        when(cartService.findCarts(userId)).thenReturn(expectedCartList);
+        List<Cart> result = cartService.findCarts(userId);
 
         assertThat(result.size()).isEqualTo(3);
         for (Cart cart : result) {
@@ -260,10 +260,10 @@ class CartServiceTest {
 
         List<Product> productList = makeProductListFixture();
 
-        when(cartService.getCarts(userId)).thenReturn(cartList);
-        when(productService.findProduct(1L)).thenReturn(productList.get(0));
-        when(productService.findProduct(2L)).thenReturn(productList.get(1));
-        when(productService.findProduct(3L)).thenReturn(productList.get(2));
+        when(cartService.findCarts(userId)).thenReturn(cartList);
+        when(productService.getProduct(1L)).thenReturn(productList.get(0));
+        when(productService.getProduct(2L)).thenReturn(productList.get(1));
+        when(productService.getProduct(3L)).thenReturn(productList.get(2));
 
         int expectedSum = calculateExpectedSum(cartList, productList);
         int actualSum = cartService.calculateTotalPrice(userId);

--- a/src/test/java/flab/commercemarket/product/service/ProductServiceTest.java
+++ b/src/test/java/flab/commercemarket/product/service/ProductServiceTest.java
@@ -101,7 +101,7 @@ class ProductServiceTest {
         // when
         when(productMapper.findById(productId)).thenReturn(Optional.of(product));
 
-        Product foundProduct = productService.findProduct(productId);
+        Product foundProduct = productService.getProduct(productId);
 
         // then
         assertThat(product).isEqualTo(foundProduct);

--- a/src/test/java/flab/commercemarket/product/service/ProductServiceTest.java
+++ b/src/test/java/flab/commercemarket/product/service/ProductServiceTest.java
@@ -1,6 +1,8 @@
 package flab.commercemarket.product.service;
 
 import flab.commercemarket.common.exception.DataNotFoundException;
+import flab.commercemarket.common.exception.ForbiddenException;
+import flab.commercemarket.common.helper.AuthorizationHelper;
 import flab.commercemarket.domain.product.ProductService;
 import flab.commercemarket.domain.product.mapper.ProductMapper;
 import flab.commercemarket.domain.product.vo.Product;
@@ -17,12 +19,14 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 class ProductServiceTest {
     @Mock
     private ProductMapper productMapper;
+
+    @Mock
+    private AuthorizationHelper authorizationHelper;
 
     @InjectMocks
     private ProductService productService;
@@ -196,14 +200,32 @@ class ProductServiceTest {
     public void deleteProductTest() throws Exception {
         // given
         long productId = 1L;
+        long loginUserId = 100L;
+        Product product = makeProductFixture((int) productId);
+        when(productMapper.findById(productId)).thenReturn(Optional.of(product));
+        doNothing().when(authorizationHelper).checkUserAuthorization(product.getSellerId(), loginUserId);
+
+        // when
+        productService.deleteProduct(product.getId(), loginUserId);
+
+        // then
+        verify(productMapper).deleteProduct(productId);
+    }
+
+    @Test
+    public void deleteProductTest_ForbiddenException() throws Exception {
+        // given
+        long productId = 1L;
+        long loginUserId = 100L;
+
         Product product = makeProductFixture((int) productId);
         when(productMapper.findById(productId)).thenReturn(Optional.of(product));
 
         // when
-        productService.deleteProduct(product.getId());
+        doThrow(new ForbiddenException("유저 권한 정보가 일치하지 않음")).when(authorizationHelper).checkUserAuthorization(product.getSellerId(), loginUserId);
 
         // then
-        verify(productMapper).deleteProduct(productId);
+        assertThrows(ForbiddenException.class, () -> productService.deleteProduct(productId, loginUserId));
     }
 
     @Test

--- a/src/test/java/flab/commercemarket/wishlist/service/WishListServiceTest.java
+++ b/src/test/java/flab/commercemarket/wishlist/service/WishListServiceTest.java
@@ -145,7 +145,7 @@ class WishListServiceTest {
         when(wishListMapper.getWishListItemByUserIdWithPagination(userId, size, page - 1)).thenReturn(wishLists);
 
         // then
-        List<WishList> result = wishListService.findWishLists(userId, page, size);
+        List<WishList> result = wishListService.getWishLists(userId, page, size);
         assertThat(wishLists).isEqualTo(result);
     }
 
@@ -183,7 +183,7 @@ class WishListServiceTest {
         when(userService.getUserById(userId)).thenReturn(new User());
         when(wishListMapper.getWishListItemByUserIdWithPagination(userId, size, page - 1)).thenReturn(wishLists.subList(0, size));
 
-        List<WishList> result = wishListService.findWishLists(userId, page, size);
+        List<WishList> result = wishListService.getWishLists(userId, page, size);
 
         // then
         assertThat(result).isEqualTo(wishLists.subList(0, size));
@@ -200,7 +200,7 @@ class WishListServiceTest {
         when(wishListMapper.isExistentUser(userId)).thenReturn(false);
 
         // then
-        assertThrows(DataNotFoundException.class, () -> wishListService.findWishLists(userId, page, size));
+        assertThrows(DataNotFoundException.class, () -> wishListService.getWishLists(userId, page, size));
     }
 
     @Test
@@ -211,7 +211,7 @@ class WishListServiceTest {
 
         // when
         when(wishListMapper.getWishListCountByUserId(userId)).thenReturn(count);
-        int result = wishListService.findWishListCountByUserId(userId);
+        int result = wishListService.getWishListCountByUserId(userId);
 
         // then
         assertThat(count).isEqualTo(result);


### PR DESCRIPTION
## get메서드 네이밍 변경 및 Product null 체크 로직 추가

### 목적

### 내용
1. getVerifyXXX() 메서드 네이밍을 getXXX()로 변경했습니다.
    - 기존에는 데이터가 있는지 없는지 확인하는 메서드의 네이밍으로 getVerifyXXX()를 사용하고 있었습니다.
    - 그러나 해당 네이밍은 데이터의 유효성을 검증하는 것보다는 데이터 조회를 의미하는 네이밍입니다.
    - 따라서 해당 메서드 네이밍을 getXXX()로 변경하였습니다.

2. `WishListService` exist 쿼리로 검증 로직 변경
    - `WishListService` 내부에서 데이터 조회로직을 반환값 없이 검증하는 용도로 사용하던 방식을 개선하였습니다.
    - 이전에는 `ProductService`와 `UserService`를 불필요하게 의존하여 의존성이 복잡하였고, 메서드가 여러 역할을 하고 있어 단일 책임 원칙을 위배하는 문제가 있었습니다.
    - 이제는 해당 검증 로직을 더 명확하게 분리하여 단일 책임을 준수하도록 변경하였습니다.

3. 여러건 조회 메서드 getXXX()에서 findXXX()로 네이밍 변경
    - 페이지네이션을 적용한 여러건 조회 메서드에서 데이터가 없을 경우 null을 반환합니다.
    - 이에 따라 기존의 getXXX() 메서드 네이밍을 findXXX()로 변경하였습니다.
    - 이전 코드리뷰에서, getXXX()는 예외를 던지고 findXXX()는 null 을 반환하는 경우가 많다고 피드백 주신 내용을 반영했습니다.

4. ProductService.updateProduct() 메서드에 null 체크 로직을 추가했습니다.

### 영향
- 기존의 메서드 네이밍 및 의존성 구조에 변화가 생길 수 있습니다.

### 관련 이슈
#42 #18

### 리뷰포인트
- 현재 ProductService.updateProduct() 메서드에 적용한 null 체크 로직에 validation 라이브러리, aop 등의 방법이 적용하는 것이 더 좋은 방법인지 여쭤보고 싶습니다.🤔
