### PR TITLE
refactor: DB 이중화

### DIFF
--- a/src/main/java/flab/commercemarket/common/config/JasyptConfig.java
+++ b/src/main/java/flab/commercemarket/common/config/JasyptConfig.java
@@ -1,4 +1,4 @@
-package flab.commercemarket.config;
+package flab.commercemarket.common.config;
 
 import lombok.extern.slf4j.Slf4j;
 import org.jasypt.encryption.StringEncryptor;

--- a/src/main/java/flab/commercemarket/common/datasource/DataSourceConfig.java
+++ b/src/main/java/flab/commercemarket/common/datasource/DataSourceConfig.java
@@ -1,0 +1,71 @@
+package flab.commercemarket.common.datasource;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
+
+import javax.sql.DataSource;
+import java.util.HashMap;
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class DataSourceConfig {
+
+    private final String MASTER_SERVER = "MASTER";
+    private final String SLAVE_SERVER = "SLAVE";
+
+    private final DataSourceProperties masterDataSourceProperties;
+    private final DataSourceProperties slaveDataSourceProperties;
+
+    @Bean
+    @Primary
+    public DataSource dataSource() {
+        DataSource determinedDataSource = routingDataSource(sourceDataSource(), replicaDataSource());
+        return new LazyConnectionDataSourceProxy(determinedDataSource);
+    }
+
+    @Bean
+    @Qualifier(MASTER_SERVER)
+    public DataSource sourceDataSource() {
+        return DataSourceBuilder.create()
+                .url(masterDataSourceProperties.getUrl())
+                .username(masterDataSourceProperties.getUsername())
+                .password(masterDataSourceProperties.getPassword())
+                .driverClassName(masterDataSourceProperties.getDriverClassName())
+                .build();
+    }
+
+    @Bean
+    @Qualifier(SLAVE_SERVER)
+    public DataSource replicaDataSource() {
+        return DataSourceBuilder.create()
+                .url(slaveDataSourceProperties.getUrl())
+                .username(slaveDataSourceProperties.getUsername())
+                .password(slaveDataSourceProperties.getPassword())
+                .driverClassName(slaveDataSourceProperties.getDriverClassName())
+                .build();
+    }
+
+    @Bean
+    public DataSource routingDataSource(
+            @Qualifier(MASTER_SERVER) DataSource sourceDataSource,
+            @Qualifier(SLAVE_SERVER) DataSource replicaDataSource) {
+
+        RoutingDataSource routingDataSource = new RoutingDataSource();
+
+        HashMap<Object, Object> dataSourceMap = new HashMap<>();
+        dataSourceMap.put("master", sourceDataSource);
+        dataSourceMap.put("slave", replicaDataSource);
+
+        routingDataSource.setTargetDataSources(dataSourceMap);
+        routingDataSource.setDefaultTargetDataSource(sourceDataSource);
+
+        return routingDataSource;
+    }
+}

--- a/src/main/java/flab/commercemarket/common/datasource/DataSourceProperties.java
+++ b/src/main/java/flab/commercemarket/common/datasource/DataSourceProperties.java
@@ -1,0 +1,18 @@
+package flab.commercemarket.common.datasource;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties(prefix = "spring.datasource.master")
+public class DataSourceProperties {
+
+    private String url;
+    private String username;
+    private String password;
+    private String driverClassName;
+}

--- a/src/main/java/flab/commercemarket/common/datasource/RoutingDataSource.java
+++ b/src/main/java/flab/commercemarket/common/datasource/RoutingDataSource.java
@@ -1,0 +1,22 @@
+package flab.commercemarket.common.datasource;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+@Slf4j
+public class RoutingDataSource extends AbstractRoutingDataSource {
+    @Override
+    protected Object determineCurrentLookupKey() {
+
+        boolean isReadOnly = TransactionSynchronizationManager.isCurrentTransactionReadOnly();
+
+        if (isReadOnly) {
+            log.debug("Slave 서버로 요청");
+            return "slave";
+        } else {
+            log.debug("Master 서버로 요청");
+            return "master";
+        }
+    }
+}

--- a/src/main/resources/application-replication.yml
+++ b/src/main/resources/application-replication.yml
@@ -1,0 +1,35 @@
+spring:
+  datasource:
+    master:
+      url: ENC(e2cBaAt1JL7IxNalA7pN7kVYg6pg0Y5nTWPjF9UlTkcV0pEfbwrBht76CIqnTnl9)
+      username: ENC(0TzQJZvEE7TpaAexvkbLwA==)
+      password: ENC(OI5c6BncKMZXJabXAubyfw==)
+      driver-class-name: ENC(Bhpswp3jpRS+YqAIXt+8U94M6BqOWpdQP1osszD1FqUBG6SxUMgtDw==)
+    slave:
+      url: ENC(J/3+BIBO6/ugVfZWB9MDFA7jZc0VtqXUqof87z+ysW8CZitTuSNpUn5SK4vnWZEO)
+      username: ENC(03gowqi1UzWEEWdc13bX+A==)
+      password: ENC(GOoxTZARqOXfIVa+NWeuSw==)
+      driver-class-name: ENC(Bhpswp3jpRS+YqAIXt+8U94M6BqOWpdQP1osszD1FqUBG6SxUMgtDw==)
+
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true
+    show-sql: true
+
+  mybatis:
+    type-aliases-package: flab.commercemarket
+    mapper-locations: mybatis/**/*.xml
+    configuration:
+      map-underscore-to-camel-case: true
+
+  jasypt:
+    encryptor:
+      bean: jasyptStringEncryptor
+
+iamport:
+  host: api.iamport.kr
+  imp_key: ENC(TP0S4I3d5gj7hxH5gVSrRCK5PbESBuXWTqPANtm1+h8=)
+  imp_secret: ENC(F9R6giwITWVe6tXCkiv6rvHX/it3CBJEIibUBLX+3/NPzNT0tqcGe0tc9QWUoc2bdgFDTYKg5D1YG4mIix2IsWK+Zkdwa+M3IFZHLHp5p9kAUucmExCLIsygMcKDRXG8)


### PR DESCRIPTION
## 데이터베이스 이중화


### 목적
- 데이터베이스 Failover를 극복할 수 있습니다.
- `@transaction(readOnly = true)` 옵션의 요청을 slave DB로 보내 부하를 분산시킬 수 있습니다.

### 내용
- docker 컨테이너로 master DB와 slave DB를 띄워 데이터베이스를 이중화 했습니다.
- application-replica.yml 파일에서 master와 slave DataSource는 로컬 도커 컨터이너의 mysql-master와 mysql-slave에 설정되어 있습니다.
- 또한 jasypt 라이브러리를 통해 DB 관련 정보를 암호화 했습니다.
- DB 이중화 관련 코드가 추가되었습니다.
- 기본 `JasyptConfig` 패키지 위치를 수정했습니다.

### 영향
- 데이터베이스 이중화를 통해 부하를 분산시키고 Failover를 극복할 수 있을 것입니다.
- 애플리케이션을 실행시키기 위해 docker 컨테이너를 띄워야 합니다.

### 관련 이슈
#56 

### 참고 사항
- https://taebong98.notion.site/readOnly-Failover-b359519028874a898f580eab2dd825b4?pvs=4
