### PR TITLE
refactor: index 적용

### DIFF
--- a/src/main/java/flab/commercemarket/domain/cart/vo/Cart.java
+++ b/src/main/java/flab/commercemarket/domain/cart/vo/Cart.java
@@ -11,6 +11,10 @@ import javax.persistence.*;
 @Setter
 @Entity
 @NoArgsConstructor
+@Table(indexes = {
+        @Index(name = "idx_user_id", columnList = "user_id"),
+        @Index(name = "idx_product_id", columnList = "product_id")
+})
 public class Cart {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/flab/commercemarket/domain/order/vo/Order.java
+++ b/src/main/java/flab/commercemarket/domain/order/vo/Order.java
@@ -17,6 +17,7 @@ import java.util.List;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@Table(indexes = @Index(name = "idx_order_id", columnList = "id"))
 public class Order {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/flab/commercemarket/domain/order/vo/OrderProduct.java
+++ b/src/main/java/flab/commercemarket/domain/order/vo/OrderProduct.java
@@ -14,6 +14,10 @@ import java.math.BigDecimal;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@Table(indexes = {
+        @Index(name = "idx_product_id", columnList = "product_id"),
+        @Index(name = "idx_order_id", columnList = "order_id")
+})
 public class OrderProduct {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/flab/commercemarket/domain/payment/vo/Payment.java
+++ b/src/main/java/flab/commercemarket/domain/payment/vo/Payment.java
@@ -3,6 +3,8 @@ package flab.commercemarket.domain.payment.vo;
 import flab.commercemarket.controller.payment.dto.PaymentResponseDto;
 import lombok.*;
 
+import javax.persistence.Index;
+import javax.persistence.Table;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
@@ -10,6 +12,9 @@ import java.time.LocalDateTime;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@Table(indexes = {
+        @Index(name = "idx_payment_id", columnList = "id")
+})
 public class Payment {
     private Long id;
     private String impUid;

--- a/src/main/java/flab/commercemarket/domain/product/repository/ProductRepositoryCustom.java
+++ b/src/main/java/flab/commercemarket/domain/product/repository/ProductRepositoryCustom.java
@@ -2,9 +2,7 @@ package flab.commercemarket.domain.product.repository;
 
 import flab.commercemarket.domain.product.vo.Product;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.Lock;
 
-import javax.persistence.LockModeType;
 import java.util.List;
 
 public interface ProductRepositoryCustom {

--- a/src/main/java/flab/commercemarket/domain/product/repository/ProductRepositoryImpl.java
+++ b/src/main/java/flab/commercemarket/domain/product/repository/ProductRepositoryImpl.java
@@ -20,8 +20,7 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
     public List<Product> findByKeyword(String keyword, Pageable pageable) {
         return queryFactory
                 .selectFrom(QProduct.product)
-                .from(QProduct.product)
-                .where(QProduct.product.name.contains(keyword))
+                .where(QProduct.product.name.like(keyword + "%"))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
@@ -31,7 +30,7 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
     public long countSearchProductByKeyword(String keyword) {
         return queryFactory
                 .selectFrom(QProduct.product)
-                .where(QProduct.product.name.contains(keyword))
+                .where(QProduct.product.name.like(keyword + "%"))
                 .stream()
                 .count();
     }

--- a/src/main/java/flab/commercemarket/domain/product/vo/Product.java
+++ b/src/main/java/flab/commercemarket/domain/product/vo/Product.java
@@ -13,6 +13,7 @@ import javax.persistence.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @OptimisticLocking
+@Table(indexes = @Index(name = "idx_product_name", columnList = "name"))
 public class Product {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/flab/commercemarket/domain/user/vo/User.java
+++ b/src/main/java/flab/commercemarket/domain/user/vo/User.java
@@ -3,15 +3,16 @@ package flab.commercemarket.domain.user.vo;
 import flab.commercemarket.controller.user.dto.UserResponseDto;
 import lombok.*;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
+import javax.persistence.*;
 
 @Getter
 @Setter
 @NoArgsConstructor
 @Entity(name = "market_user")
+@Table(indexes = {
+        @Index(name = "idx_username", columnList = "username"),
+        @Index(name = "idx_user_id", columnList = "id")
+})
 public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/flab/commercemarket/domain/wishlist/vo/WishList.java
+++ b/src/main/java/flab/commercemarket/domain/wishlist/vo/WishList.java
@@ -15,6 +15,10 @@ import javax.persistence.*;
 @Entity
 @NoArgsConstructor
 @AllArgsConstructor
+@Table(indexes = {
+        @Index(name = "idx_product_id", columnList = "product_id"),
+        @Index(name = "idx_user_id", columnList = "user_id")
+})
 public class WishList {
 
     @Id


### PR DESCRIPTION
## Index 적용


### 목적
- 인덱스를 적용하여 데이터베이스 성능을 향상시키고 검색속도를 개선합니다.

### 내용
- MySQL의 디폴트 인덱스인 B-Tree 인덱스를 기준으로 인덱스를 적용했습니다.
- WHERE 절에서 자주 사용하는 검색조건에 인덱스를 적용했습니다.

#### `User`
- 로그인 시 사용되는 `username`컬럼에 인덱스를 설정했습니다. 
- 다른 비즈니스 로직에서 자주 사용되는(`userService.getUser(long userId)` ) 기본키에 인덱스를 설정했습니다.

#### `Order`: 
- 검색조건에 자주 사용되는 기본키에 인덱스를 설정했습니다.

#### `OrderProduct`: 
- `product_id`에 인덱스를 설정해서 `Product`와의 조인연산을 최적화 시켰습니다.
- `order_id`에 인덱스를 설정해서 `Order`와의 조인연선을 최적화 시켰습니다.

#### `Product`
- 제품을 검색할 때 제품이름(product_name)과 같은 필드에 인덱스를 생성하여 검색 결과를 최적화 했습니다.
- B-Tree 인덱스의 전방일치를 사용하기 위해 키워드 검색 로직을 `LIKE %keyword%`에서 `LIKE keyword%`로 변경했습니다. (`ProductRepositoryImpl.searchProductByKeyword()`)

#### `Order`
- PK에 인덱스를 설정하여 특정 주문에 대한 검색 성능을 올렸습니다. → 관련해서 리뷰포인트에 질문 드린 내용이 있습니다!

#### `WishList`
- 사용자의 찜 목록을 조회하거나 관리할 때 `user_id`와 `product_id`에 인덱스를 적용했습니다.

#### `Payment`
- 결제ID(PK)를 기반으로 검색할 때 인덱스를 사용하여 검색속도를 향상시켰습니다.

### 영향
- 검색 속도가 향상됩니다.
- 일부 쓰기작업의 성능이 저하될 수 있습니다.
- Index의 크기에 따라 디스크 공간 사용량이 늘어날 수 있습니다.

### 관련 이슈
#55 

### 참고 사항
- B-Tree 인덱스의 전방일치를 활용하기 위해 상품 키워드 검색을 `LIKE %keyword%` 에서 `LIKE keyword%`로 변경했습니다.
- 이전에 User 테이블 `username`과 `email` 필드에 복합키 적용 관련 피드백을 주셨습니다. 그런데 `where username = ? and email = ?` 쿼리를 사용하는 부분이 없어서 복합키 적용을 하지 않았습니다.

### 리뷰포인트
 - 대부분의 DBMS에서 기본적으로 기본키(PK) 열에 대한 인덱스가 자동으로 설정되는 것으로 알고 있습니다! 비즈니스 로직에서 `where id = ?` 와 같이 기본키만 검색조건으로 활용하는 상황에서, pk에 대한 인덱스를 명시적으로 작성해야 하는지, 생략해야하는지 피드백 부탁드리고 싶습니다.