### PR TITLE
Feature/76-get-user-info

### DIFF
--- a/src/main/java/flab/commercemarket/common/helper/AuthorizationHelper.java
+++ b/src/main/java/flab/commercemarket/common/helper/AuthorizationHelper.java
@@ -1,17 +1,20 @@
 package flab.commercemarket.common.helper;
 
 import flab.commercemarket.common.exception.ForbiddenException;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Component;
+
 
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class AuthorizationHelper {
 
-    public void checkUserAuthorization(long ownerUserId, long loginUserId) {
-        if (ownerUserId != loginUserId) {
-            log.info("dataUserId = {}, loginUserId = {}", ownerUserId, loginUserId);
-            throw new ForbiddenException("유저 권한정보가 일치하지 않음");
-        }
+    public String getPrincipalEmail() {
+        OAuth2User principal = (OAuth2User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        return principal.getAttribute("email");
     }
 }

--- a/src/main/java/flab/commercemarket/controller/cart/CartController.java
+++ b/src/main/java/flab/commercemarket/controller/cart/CartController.java
@@ -1,5 +1,6 @@
 package flab.commercemarket.controller.cart;
 
+import flab.commercemarket.common.helper.AuthorizationHelper;
 import flab.commercemarket.common.responsedto.PageResponseDto;
 import flab.commercemarket.controller.cart.dto.CartDto;
 import flab.commercemarket.controller.cart.dto.CartResponseDto;
@@ -19,37 +20,30 @@ import java.util.stream.Collectors;
 public class CartController {
 
     private final CartService cartService;
+    private final AuthorizationHelper authorizationHelper;
 
     @PostMapping
     public CartResponseDto postCart(@RequestBody CartDto cartDto) {
-        // todo 세션정보로 로그인한 userId 확인 -> Dto에서 사용하는 userId 삭제
-        long userId = cartDto.getUserId();
-
-        Cart registerCart = cartService.registerCart(cartDto, userId);
+        Cart registerCart = cartService.registerCart(cartDto, authorizationHelper.getPrincipalEmail());
         return registerCart.toCartResponseDto();
     }
 
     @PatchMapping("/{cartId}")
-    public CartResponseDto patchCart(@PathVariable("cartId") long cartId,
-                                     @RequestBody CartDto cartDto) {
-        // todo 로그인 기능 추가 이후 해당 장바구니 수정에 대한 권한 검증로직이 추가되어야 합니다.
-
-        long userId = cartDto.getUserId(); // todo 토큰에서 조회하도록 변경
-
-        Cart updatedCart = cartService.updateCart(cartDto, cartId, userId);
+    public CartResponseDto patchCart(@PathVariable("cartId") long cartId, @RequestBody CartDto cartDto) {
+        Cart updatedCart = cartService.updateCart(cartDto, cartId, authorizationHelper.getPrincipalEmail());
         return updatedCart.toCartResponseDto();
     }
 
     @GetMapping
-    public PageResponseDto<CartResponseDto> getCarts(@RequestParam long userId, @RequestParam int page, @RequestParam int size) {
-        // todo 로그인 기능 추가 이후 userId를 조회하는 로직 변경 -> 토큰에서 조회 등
-        List<Cart> carts = cartService.findCarts(userId, page, size);
+    public PageResponseDto<CartResponseDto> getCarts(@RequestParam int page, @RequestParam int size) {
+        String principalEmail = authorizationHelper.getPrincipalEmail();
+        List<Cart> carts = cartService.findCarts(principalEmail, page, size);
 
         List<CartResponseDto> cartResponseDto = carts.stream()
                 .map(Cart::toCartResponseDto)
                 .collect(Collectors.toList());
 
-        long totalElements = cartService.countCartByUserId(userId);
+        long totalElements = cartService.countCartByUserId(principalEmail);
 
         return PageResponseDto.<CartResponseDto>builder()
                 .page(page)
@@ -61,15 +55,14 @@ public class CartController {
 
     @DeleteMapping("/{cartId}")
     public void deleteCart(@PathVariable long cartId) {
-        // todo 로그인 기능 추가 이후 해당 장바구니 삭제에 대한 권한 검증로직이 추가되어야 합니다.
-        long loginUserId = 1L; // 토큰에서 조회하는 로직으로 변경해야함
-        cartService.deleteCart(cartId, loginUserId);
+        String principalEmail = authorizationHelper.getPrincipalEmail();
+        cartService.deleteCart(principalEmail, cartId);
     }
 
-    @GetMapping("/{userId}")
-    public int getPrice(@PathVariable long userId) {
-        // todo 로그인 기능 추가 이후 userId를 조회하는 로직 변경
-        return cartService.calculateTotalPrice(userId);
+    @GetMapping("/price")
+    public int getPrice() {
+        String principalEmail = authorizationHelper.getPrincipalEmail();
+        return cartService.calculateTotalPrice(principalEmail);
     }
 }
 

--- a/src/main/java/flab/commercemarket/controller/cart/dto/CartDto.java
+++ b/src/main/java/flab/commercemarket/controller/cart/dto/CartDto.java
@@ -8,7 +8,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class CartDto {
-    private long userId;
     private long productId;
     private int quantity;
 }

--- a/src/main/java/flab/commercemarket/controller/wishlist/WishListController.java
+++ b/src/main/java/flab/commercemarket/controller/wishlist/WishListController.java
@@ -1,5 +1,6 @@
 package flab.commercemarket.controller.wishlist;
 
+import flab.commercemarket.common.helper.AuthorizationHelper;
 import flab.commercemarket.common.responsedto.PageResponseDto;
 import flab.commercemarket.controller.wishlist.dto.WishListResponseDto;
 import flab.commercemarket.domain.wishlist.WishListService;
@@ -18,18 +19,21 @@ import java.util.stream.Collectors;
 public class WishListController {
 
     private final WishListService wishListService;
+    private final AuthorizationHelper authorizationHelper;
 
     @PostMapping("/{productId}")
-    public WishListResponseDto postWishList(@PathVariable long productId, @RequestParam long userId) {
+    public WishListResponseDto postWishList(@PathVariable long productId) {
         // TODO @RequestParam long userId 제거 -> 로그인 정보에서 userId 가져오도록 refactoring
-        WishList wishList = wishListService.registerWishList(userId, productId);
+        String principalEmail = authorizationHelper.getPrincipalEmail();
+        WishList wishList = wishListService.registerWishList(principalEmail, productId);
         return wishList.toWishlistResponseDto();
     }
 
     @GetMapping
-    public PageResponseDto<WishListResponseDto> getWishLists(@RequestParam long userId, @RequestParam int page, @RequestParam int size) {
-        List<WishList> wishLists = wishListService.findWishLists(userId, page, size);
-        long totalElements = wishListService.countWishListByUserId(userId);
+    public PageResponseDto<WishListResponseDto> getWishLists(@RequestParam int page, @RequestParam int size) {
+        String principalEmail = authorizationHelper.getPrincipalEmail();
+        List<WishList> wishLists = wishListService.findWishLists(principalEmail, page, size);
+        long totalElements = wishListService.countWishListByUserId(principalEmail);
 
         List<WishListResponseDto> wishListResponseList = wishLists.stream()
                 .map(WishList::toWishlistResponseDto)
@@ -44,7 +48,8 @@ public class WishListController {
     }
 
     @DeleteMapping("/{wishListId}")
-    public void deleteWishList(@PathVariable long wishListId, @RequestParam long userId) {
-        wishListService.deleteWishList(userId, wishListId);
+    public void deleteWishList(@PathVariable long wishListId) {
+        String principalEmail = authorizationHelper.getPrincipalEmail();
+        wishListService.deleteWishList(principalEmail, wishListId);
     }
 }

--- a/src/main/java/flab/commercemarket/domain/cart/repository/CartRepositoryCustom.java
+++ b/src/main/java/flab/commercemarket/domain/cart/repository/CartRepositoryCustom.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 public interface CartRepositoryCustom {
     List<Cart> findCartByUserId(long userId, Pageable pageable);
-    long countCartByUserId(long userId);
+    long countCartByEmail(String email);
     List<Cart> findAllByUserId(long userId);
     boolean isAlreadyExistentProductInUserCart(long userId, long productId);
 }

--- a/src/main/java/flab/commercemarket/domain/cart/repository/CartRepositoryImpl.java
+++ b/src/main/java/flab/commercemarket/domain/cart/repository/CartRepositoryImpl.java
@@ -28,11 +28,11 @@ public class CartRepositoryImpl implements CartRepositoryCustom {
     }
 
     @Override
-    public long countCartByUserId(long userId) {
+    public long countCartByEmail(String email) {
         Long totalCount = queryFactory
                 .select(QCart.cart.count())
                 .from(QCart.cart)
-                .where(QCart.cart.user.id.eq(userId))
+                .where(QCart.cart.user.email.eq(email))
                 .fetchOne();
 
         return totalCount != null ? totalCount : 0L;

--- a/src/main/java/flab/commercemarket/domain/user/UserService.java
+++ b/src/main/java/flab/commercemarket/domain/user/UserService.java
@@ -38,6 +38,12 @@ public class UserService {
                 .orElseThrow(() -> new DataNotFoundException("해당 id의 유저가 없습니다."));
     }
 
+    public User getUserByEmail(String email) {
+        log.info("Start getUserByEmail: {}", email);
+        return userRepository.findByEmail(email)
+                .orElseThrow(() -> new DataNotFoundException("해당 email의 유저가 없습니다."));
+    }
+
     @Transactional
     public void deleteUser(long userId) {
         log.info("Start delete User");


### PR DESCRIPTION
## SecurityContextHolder로 principal 정보 획득


### 목적
기존 클라이언트 요청으로 부터 입력받던 사용자 정보를 Spring Security의 기능을 활용하여 principal 정보를 획득합니다.

### 내용
- Spring Security의 SecurityContextHolder를 활용하여 principal 정보를 얻는 방법을 구현합니다.
- 이전까지는 클라이언트로부터 userId를 받아 사용자 정보를 확인했으나, 새로운 접근 방식으로 고유한 값인 이메일 주소(email)를 사용하여 데이터베이스에서 사용자 정보를 조회하고 비즈니스 로직을 처리합니다.
- Principal 정보를 얻는 로직은 AuthorizationHelper 클래스로 위임되었습니다.
- AuthorizationHelper 클래스는 사용자가 수정하려는 데이터에 대한 권한을 검사하는 역할을 수행하며, 권한 검사 로직은 각 *Service (비즈니스 로직)에 위임됩니다.
    - 권한 검사 로직은 여러 비즈니스 로직에서 공통으로 필요한 횡단 관심사(Aspect)로서 AOP(Aspect-Oriented Programming)를 고려 중입니다.

### 영향
사용자 정보를 클라이언트 요청으로 받지 않을 수 있습니다.

### 관련 이슈
#76 

### 참고 사항
- SecurityContextHolder에서 사용되는 ThreadLocal 개념에 대해 학습했습니다. [학습 내용 정리](https://velog.io/@taebong98/Spring-Security%EB%A1%9C-%EC%9A%94%EC%B2%AD%EC%9D%84-%EB%B3%B4%EB%82%B4%EB%8A%94-%EC%82%AC%EC%9A%A9%EC%9E%90-%EC%A0%95%EB%B3%B4-%ED%9A%8D%EB%93%9D%ED%95%98%EB%8A%94-%EB%B0%A9%EB%B2%95)
- [테스트케이스 관련 PR](https://github.com/f-lab-edu/commerce-market/pull/75) merge 이후 테스트케이스를 추가적으로 수정해야할 부분이 있습니다.
