### PR TITLE
refactor/78-cart-benchmark

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ plugins {
 	id 'org.springframework.boot' version '2.7.12'
 	id 'io.spring.dependency-management' version '1.0.15.RELEASE'
 	id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
+	id "me.champeau.jmh" version "0.6.2"
 }
 
 group = 'com.flab'
@@ -63,4 +64,10 @@ configurations {
 }
 compileQuerydsl {
 	options.annotationProcessorPath = configurations.querydsl
+}
+
+jmh {
+	fork = 1
+	warmupIterations = 1
+	iterations = 1
 }

--- a/src/jmh/java/sample/CartJmh.java
+++ b/src/jmh/java/sample/CartJmh.java
@@ -1,0 +1,85 @@
+package sample;
+
+import flab.commercemarket.domain.cart.vo.Cart;
+import flab.commercemarket.domain.product.vo.Product;
+import flab.commercemarket.domain.user.vo.User;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(value = 1, warmups = 2)
+public class CartJmh {
+    List<Cart> cartList = new ArrayList<>();
+
+    @Benchmark
+    public void forLoopBenchmark(Blackhole blackhole) {
+        blackhole.consume(forLoop(1));
+    }
+
+    @Benchmark
+    public void streamBenchmark(Blackhole blackhole) {
+        blackhole.consume(stream(1));
+    }
+
+    @Benchmark
+    public void parallelStreamBenchmark(Blackhole blackhole) {
+        blackhole.consume(parallelStream(1));
+    }
+
+    public int forLoop(long userId) {
+        List<Cart> carts = findAllByUserId(userId);
+
+        int sum = 0;
+
+        for (Cart cart : carts) {
+            int quantity = cart.getQuantity();
+            long productId = cart.getProductId();
+            int price = getProduct(productId).getPrice();
+            sum += quantity * price;
+        }
+        return sum;
+    }
+
+    public int stream(long userId) {
+        List<Cart> carts = findAllByUserId(userId);
+
+        return carts.stream()
+                .mapToInt(cart -> {
+                    int quantity = cart.getQuantity();
+                    long productId = cart.getProductId();
+                    int price = getProduct(productId).getPrice();
+                    return quantity * price;
+                }).sum();
+    }
+
+    public int parallelStream(long userId) {
+        List<Cart> carts = findAllByUserId(userId);
+
+        return carts.parallelStream()
+                .mapToInt(cart -> {
+                    int quantity = cart.getQuantity();
+                    long productId = cart.getProductId();
+                    int price = getProduct(productId).getPrice();
+                    return quantity * price;
+                }).sum();
+    }
+
+    public List<Cart> findAllByUserId(long userId) {
+        User user = User.builder().id(userId).build();
+        for (int i = 1; i <= 100; i++) {
+            Product product = Product.builder().id((long) i).price(i * 10000).build();
+            cartList.add(Cart.builder().user(user).product(product).quantity(i).build());
+        }
+        return cartList;
+    }
+
+    public Product getProduct(long productId) {
+        return cartList.get((int) (productId - 1)).getProduct();
+    }
+}

--- a/src/main/java/flab/commercemarket/domain/cart/CartService.java
+++ b/src/main/java/flab/commercemarket/domain/cart/CartService.java
@@ -95,17 +95,13 @@ public class CartService {
 
         List<Cart> carts = cartRepository.findAllByUserId(userId);
 
-        int sum = 0;
-
-        for (Cart cart : carts) {
-            int quantity = cart.getQuantity();
-            long productId = cart.getProductId();
-            int price = productService.getProduct(productId).getPrice();
-            sum += quantity * price;
-        }
-
-        log.info("Calculate cart's total price");
-        return sum;
+        return carts.parallelStream()
+                .mapToInt(cart -> {
+                    int quantity = cart.getQuantity();
+                    long productId = cart.getProductId();
+                    int price = productService.getProduct(productId).getPrice();
+                    return quantity * price;
+                }).sum();
     }
 
     private Cart getCart(long cartId) {


### PR DESCRIPTION
## JMH 결과 반영

### 목적
장바구니 총 금액 계산 로직을 벤치마킹하여 최적화합니다.

### 내용
장바구니 총 금액 계산 로직을 JMH로 테스트한 결과를 반영합니다. JMH 결과에 따르면 병렬 스트림 연산이 가장 효율적이었으므로 이를 기반으로 코드를 최적화합니다. 이로써 장바구니 총 금액 계산에 대한 성능 향상을 달성할 수 있습니다.

### 영향
장바구니 총 금액 계산 성능 향상
병렬 스트림 연산을 통한 최적화

### 관련 이슈
#78 

### 참고 사항
https://github.com/f-lab-edu/commerce-market/wiki/JMH-%EB%B2%A4%EC%B9%98%EB%A7%88%ED%82%B9%EC%9D%84-%ED%86%B5%ED%95%9C-%EC%BD%94%EB%93%9C-%EC%B5%9C%EC%A0%81%ED%99%94