### PR TITLE
Feature/74-fix-n+1

### DIFF
--- a/src/main/java/flab/commercemarket/common/helper/AuthorizationHelper.java
+++ b/src/main/java/flab/commercemarket/common/helper/AuthorizationHelper.java
@@ -17,4 +17,9 @@ public class AuthorizationHelper {
         OAuth2User principal = (OAuth2User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         return principal.getAttribute("email");
     }
+
+    public String getPrincipalEmail() {
+        OAuth2User principal = (OAuth2User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        return principal.getAttribute("email");
+    }
 }

--- a/src/main/java/flab/commercemarket/common/helper/AuthorizationHelper.java
+++ b/src/main/java/flab/commercemarket/common/helper/AuthorizationHelper.java
@@ -1,6 +1,5 @@
 package flab.commercemarket.common.helper;
 
-import flab.commercemarket.common.exception.ForbiddenException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -12,11 +11,6 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class AuthorizationHelper {
-
-    public String getPrincipalEmail() {
-        OAuth2User principal = (OAuth2User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        return principal.getAttribute("email");
-    }
 
     public String getPrincipalEmail() {
         OAuth2User principal = (OAuth2User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();

--- a/src/main/java/flab/commercemarket/controller/order/dto/OrderGetResponseDto.java
+++ b/src/main/java/flab/commercemarket/controller/order/dto/OrderGetResponseDto.java
@@ -1,7 +1,6 @@
 package flab.commercemarket.controller.order.dto;
 
-import flab.commercemarket.domain.order.vo.OrderProduct;
-import flab.commercemarket.domain.user.vo.User;
+import flab.commercemarket.controller.user.dto.UserResponseDto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,10 +14,10 @@ import java.util.List;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class OrderResponseDto {
+public class OrderGetResponseDto {
     private long id;
-    private User user;
-    private List<OrderProduct> orderProduct;
+    private UserResponseDto user;
+    private List<OrderProductDto>orderProductDto;
     private LocalDateTime orderedAt;
     private BigDecimal orderPrice;
     private String merchantUid;

--- a/src/main/java/flab/commercemarket/controller/order/dto/OrderProductDto.java
+++ b/src/main/java/flab/commercemarket/controller/order/dto/OrderProductDto.java
@@ -1,0 +1,17 @@
+package flab.commercemarket.controller.order.dto;
+
+import flab.commercemarket.controller.product.dto.ProductResponseDto;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Builder
+public class OrderProductDto {
+    private long id;
+    private ProductResponseDto productResponseDto;
+    private int quantity;
+}

--- a/src/main/java/flab/commercemarket/controller/order/dto/OrderRequestDto.java
+++ b/src/main/java/flab/commercemarket/controller/order/dto/OrderRequestDto.java
@@ -10,8 +10,6 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class OrderRequestDto {
-    private long buyerId;
-    private String requestMessage;
     private List<OrderProductRequestDto> products;
 }
 

--- a/src/main/java/flab/commercemarket/controller/product/ProductController.java
+++ b/src/main/java/flab/commercemarket/controller/product/ProductController.java
@@ -1,5 +1,6 @@
 package flab.commercemarket.controller.product;
 
+import flab.commercemarket.common.helper.AuthorizationHelper;
 import flab.commercemarket.common.responsedto.PageResponseDto;
 import flab.commercemarket.controller.product.dto.ProductDto;
 import flab.commercemarket.controller.product.dto.ProductResponseDto;
@@ -20,11 +21,14 @@ import java.util.stream.Collectors;
 public class ProductController {
 
     private final ProductService productService;
+    private final AuthorizationHelper authorizationHelper;
 
     @PostMapping
     @PreAuthorize("hasRole('ROLE_USER')")
     public ProductResponseDto postProduct(@RequestBody ProductDto productDto) {
-        Product createdProduct = productService.registerProduct(productDto);
+        String email = authorizationHelper.getPrincipalEmail();
+
+        Product createdProduct = productService.registerProduct(email, productDto);
         return createdProduct.toProductResponseDto();
     }
 
@@ -32,8 +36,8 @@ public class ProductController {
     @PreAuthorize("hasRole('ROLE_USER')")
     public ProductResponseDto patchProduct(@PathVariable("productId") long productId,
                                            @RequestBody @Validated ProductDto productDto) {
-        // todo 게시물 소유자와 로그인한 userId 일치 여부 확인
-        Product updateProduct = productService.updateProduct(productId, productDto);
+        String email = authorizationHelper.getPrincipalEmail();
+        Product updateProduct = productService.updateProduct(email, productId, productDto);
 
         return updateProduct.toProductResponseDto();
     }
@@ -80,8 +84,8 @@ public class ProductController {
     @DeleteMapping("/{productId}")
     @PreAuthorize("hasAnyRole('ROLE_USER','ROLE_ADMIN')")
     public void deleteProduct(@PathVariable("productId") long productId) {
-        // todo 게시물 소유자와 로그인한 userId 일치 여부 확인
-        productService.deleteProduct(productId);
+        String email = authorizationHelper.getPrincipalEmail();
+        productService.deleteProduct(productId, email);
     }
 
     @PostMapping("/{productId}/likes")

--- a/src/main/java/flab/commercemarket/controller/product/dto/ProductDto.java
+++ b/src/main/java/flab/commercemarket/controller/product/dto/ProductDto.java
@@ -25,7 +25,4 @@ public class ProductDto {
 
     @NotNull(message = "Description cannot be null")
     private String description;
-
-    @Positive(message = "Seller ID must be a positive value")
-    private long sellerId;
 }

--- a/src/main/java/flab/commercemarket/controller/product/dto/ProductResponseDto.java
+++ b/src/main/java/flab/commercemarket/controller/product/dto/ProductResponseDto.java
@@ -8,16 +8,11 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ProductResponseDto {
-
     private Long id;
     private String name;
     private int price;
     private String imageUrl;
     private String description;
-    private int stockAmount;
-    private int salesAmount;
     private int likeCount;
-    private int dislikeCount;
     private Long sellerId;
-
 }

--- a/src/main/java/flab/commercemarket/domain/cart/CartService.java
+++ b/src/main/java/flab/commercemarket/domain/cart/CartService.java
@@ -33,7 +33,7 @@ public class CartService {
         log.info("Start registerCart");
 
         User foundUser = userService.getUserByEmail(email);
-        Product foundProduct = productService.getProduct(data.getProductId());
+        Product foundProduct = productService.getProductById(data.getProductId());
 
         checkDuplicateCartItem(foundUser.getId(), data.getProductId());
 
@@ -99,7 +99,7 @@ public class CartService {
                 .mapToInt(cart -> {
                     int quantity = cart.getQuantity();
                     long productId = cart.getProductId();
-                    int price = productService.getProduct(productId).getPrice();
+                    int price = productService.getProductById(productId).getPrice();
                     return quantity * price;
                 }).sum();
     }

--- a/src/main/java/flab/commercemarket/domain/order/OrderService.java
+++ b/src/main/java/flab/commercemarket/domain/order/OrderService.java
@@ -1,7 +1,6 @@
 package flab.commercemarket.domain.order;
 
 import flab.commercemarket.common.exception.DataNotFoundException;
-import flab.commercemarket.common.exception.ForbiddenException;
 import flab.commercemarket.common.helper.AuthorizationHelper;
 import flab.commercemarket.controller.order.dto.OrderRequestDto;
 import flab.commercemarket.domain.order.repository.OrderRepository;
@@ -30,47 +29,41 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class OrderService {
 
+    private final AuthorizationHelper authorizationHelper;
     private final UserService userService;
     private final ProductService productService;
     private final OrderRepository orderRepository;
     private final DateUtils dateUtils;
 
     @Transactional
-    public Order registerOrder(long loginUserId, OrderRequestDto orderRequestDto) {
+    public Order registerOrder(String email, OrderRequestDto orderRequestDto) {
         log.info("Start registerOrder");
-        checkUserAuthorization(orderRequestDto.getBuyerId(), loginUserId);
-        User buyer = userService.getUserById(orderRequestDto.getBuyerId());
+        User buyer = userService.getUserByEmail(email);
         List<OrderProduct> orderProductList = createOrderProductList(orderRequestDto);
-
         LocalDateTime orderedAt = LocalDateTime.now();
-        String merchantUid = merchantUidBuilder(loginUserId, orderedAt);
+        String merchantUid = merchantUidBuilder(buyer.getId(), orderedAt);
+        BigDecimal orderPrice = calculateOrderPrice(orderRequestDto);
 
-        BigDecimal orderPrice = orderProductList.stream()
-                .map(OrderProduct::getTotalPrice)
-                .reduce(BigDecimal.ZERO, BigDecimal::add);
-        log.info("주문 금액: {}", orderPrice);
-
-        Order order = Order.builder()
+        return orderRepository.save(Order.builder()
                 .user(buyer)
                 .orderProduct(orderProductList)
-                .requestMessage(orderRequestDto.getRequestMessage())
                 .orderedAt(orderedAt)
                 .orderPrice(orderPrice)
                 .merchantUid(merchantUid)
-                .build();
-
-        return orderRepository.save(order);
+                .build());
     }
 
-    @Transactional(readOnly = true)
     public Order getOrder(long orderId) {
         log.info("Start getOrder. orderId: {}", orderId);
 
         Optional<Order> optionalOrder = orderRepository.findById(orderId);
-        return optionalOrder.orElseThrow(() -> {
+        Order order = optionalOrder.orElseThrow(() -> {
             log.info("orderId: {}", orderId);
             return new DataNotFoundException("조회한 주문정보가 없음");
         });
+
+        log.info("order: {}", order);
+        return order;
     }
 
     public Order getOrderByMerchantUid(String merchantUid) {
@@ -84,49 +77,31 @@ public class OrderService {
         log.info("Start deleteOrder. orderId: {}", orderId);
 
         Order order = getOrder(orderId);
-        checkUserAuthorization(order.getUserId(), loginUserId);
+        authorizationHelper.checkUserAuthorization(order.getUserId(), loginUserId);
         orderRepository.delete(order);
     }
 
-    private List<OrderProduct> createOrderProductList(OrderRequestDto orderRequestDto) {
-        log.info("Start createOrderProductList.");
-
-        return orderRequestDto.getProducts()
-                .stream()
-                .map(orderProductRequestDto -> {
-                    Product foundProduct = productService.getProduct(orderProductRequestDto.getProductId());
-                    int quantity = orderProductRequestDto.getQuantity();
-                    BigDecimal productPrice = BigDecimal.valueOf(foundProduct.getPrice());
-                    BigDecimal productTotalPrice = productPrice.multiply(BigDecimal.valueOf(quantity));
-
-                    return OrderProduct.builder()
-                            .product(foundProduct)
-                            .quantity(quantity)
-                            .totalPrice(productTotalPrice)
-                            .build();
-                })
-                .collect(Collectors.toList());
-    }
-
     @Transactional(readOnly = true)
-    public List<Order> getOrderByDate(String startDate, String endDate, int page, int size) {
+    public List<Order> getOrderByDate(String email, String startDate, String endDate, int page, int size) {
         log.info("Start getOrderByDate.");
         LocalDateTime startDateTime = dateUtils.parseDateTime(startDate + "T00:00:00");
         LocalDateTime endDateTime = dateUtils.parseDateTime(endDate + "T23:59:59");
         log.info("Parse String to LocalDateTime. startDateTime: {}, endDateTime: {}", startDateTime, endDateTime);
 
         Pageable pageable = PageRequest.of(page - 1, size);
-        return orderRepository.findBetweenDateTime(startDateTime, endDateTime, pageable);
+        User foundUser = userService.getUserByEmail(email);
+        return orderRepository.findBetweenDateTime(foundUser.getId(), startDateTime, endDateTime, pageable);
     }
 
     @Transactional(readOnly = true)
-    public long countOrderByDate(String startDate, String endDate) {
+    public long countOrderByDate(String email, String startDate, String endDate) {
         log.info("Start countOrderByDate.");
         LocalDateTime startDateTime = dateUtils.parseDateTime(startDate + "T00:00:00");
         LocalDateTime endDateTime = dateUtils.parseDateTime(endDate + "T23:59:59");
         log.info("Parse String to LocalDateTime. startDateTime: {}, endDateTime: {}", startDateTime, endDateTime);
 
-        return orderRepository.countOrderBetweenDate(startDateTime, endDateTime);
+        User foundUser = userService.getUserByEmail(email);
+        return orderRepository.countOrderBetweenDate(foundUser.getId(), startDateTime, endDateTime);
     }
 
     // PG 사에서 사용하는 주문 고유 번호. 유니크한 값이어야함
@@ -135,10 +110,28 @@ public class OrderService {
         return String.format("merch_%03d_%d", mills, loginUserId);
     }
 
-    private void checkUserAuthorization(long ownerUserId, long loginUserId) {
-        if (ownerUserId != loginUserId) {
-            log.info("dataUserId = {}, loginUserId = {}", ownerUserId, loginUserId);
-            throw new ForbiddenException("유저 권한정보가 일치하지 않음");
-        }
+    private BigDecimal calculateOrderPrice(OrderRequestDto orderRequestDto) {
+        BigDecimal orderPrice = orderRequestDto.getProducts().stream()
+                .map(product -> {
+                    long productId = product.getProductId();
+                    Product foundProduct = productService.getProduct(productId);
+                    return BigDecimal.valueOf(product.getQuantity()).multiply(BigDecimal.valueOf(foundProduct.getPrice()));
+                })
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        return orderPrice;
+    }
+
+    private List<OrderProduct> createOrderProductList(OrderRequestDto orderRequestDto) {
+        return orderRequestDto.getProducts()
+                .stream()
+                .map(orderProductRequestDto -> {
+                    Product foundProduct = productService.getProduct(orderProductRequestDto.getProductId());
+                    int quantity = orderProductRequestDto.getQuantity();
+                    return OrderProduct.builder()
+                            .product(foundProduct)
+                            .quantity(quantity)
+                            .build();
+                })
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/flab/commercemarket/domain/order/OrderService.java
+++ b/src/main/java/flab/commercemarket/domain/order/OrderService.java
@@ -77,7 +77,6 @@ public class OrderService {
         log.info("Start deleteOrder. orderId: {}", orderId);
 
         Order order = getOrder(orderId);
-        authorizationHelper.checkUserAuthorization(order.getUserId(), loginUserId);
         orderRepository.delete(order);
     }
 
@@ -114,7 +113,7 @@ public class OrderService {
         BigDecimal orderPrice = orderRequestDto.getProducts().stream()
                 .map(product -> {
                     long productId = product.getProductId();
-                    Product foundProduct = productService.getProduct(productId);
+                    Product foundProduct = productService.getProductById(productId);
                     return BigDecimal.valueOf(product.getQuantity()).multiply(BigDecimal.valueOf(foundProduct.getPrice()));
                 })
                 .reduce(BigDecimal.ZERO, BigDecimal::add);
@@ -125,7 +124,7 @@ public class OrderService {
         return orderRequestDto.getProducts()
                 .stream()
                 .map(orderProductRequestDto -> {
-                    Product foundProduct = productService.getProduct(orderProductRequestDto.getProductId());
+                    Product foundProduct = productService.getProductById(orderProductRequestDto.getProductId());
                     int quantity = orderProductRequestDto.getQuantity();
                     return OrderProduct.builder()
                             .product(foundProduct)

--- a/src/main/java/flab/commercemarket/domain/order/repository/OrderRepositoryCustom.java
+++ b/src/main/java/flab/commercemarket/domain/order/repository/OrderRepositoryCustom.java
@@ -8,6 +8,6 @@ import java.util.List;
 import java.util.Optional;
 
 public interface OrderRepositoryCustom {
-    List<Order> findBetweenDateTime(LocalDateTime startDateTime, LocalDateTime endDateTime, Pageable pageable);
-    long countOrderBetweenDate(LocalDateTime startDateTime, LocalDateTime endDateTime);
+    List<Order> findBetweenDateTime(long userId, LocalDateTime startDateTime, LocalDateTime endDateTime, Pageable pageable);
+    long countOrderBetweenDate(long userId, LocalDateTime startDateTime, LocalDateTime endDateTime);
 }

--- a/src/main/java/flab/commercemarket/domain/order/repository/OrderRepositoryImpl.java
+++ b/src/main/java/flab/commercemarket/domain/order/repository/OrderRepositoryImpl.java
@@ -18,20 +18,20 @@ public class OrderRepositoryImpl implements OrderRepositoryCustom {
     }
 
     @Override
-    public List<Order> findBetweenDateTime(LocalDateTime startDateTime, LocalDateTime endDateTime, Pageable pageable) {
+    public List<Order> findBetweenDateTime(long userId, LocalDateTime startDateTime, LocalDateTime endDateTime, Pageable pageable) {
         return queryFactory
                 .selectFrom(order)
-                .where(order.orderedAt.between(startDateTime, endDateTime))
+                .where(order.orderedAt.between(startDateTime, endDateTime).and(order.user.id.eq(userId)))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
     }
 
     @Override
-    public long countOrderBetweenDate(LocalDateTime startDateTime, LocalDateTime endDateTime) {
+    public long countOrderBetweenDate(long userId, LocalDateTime startDateTime, LocalDateTime endDateTime) {
         return queryFactory
                 .selectFrom(order)
-                .where(order.orderedAt.between(startDateTime, endDateTime))
+                .where(order.orderedAt.between(startDateTime, endDateTime).and(order.user.id.eq(userId)))
                 .stream()
                 .count();
     }

--- a/src/main/java/flab/commercemarket/domain/order/vo/Order.java
+++ b/src/main/java/flab/commercemarket/domain/order/vo/Order.java
@@ -4,6 +4,7 @@ import flab.commercemarket.controller.order.dto.OrderGetResponseDto;
 import flab.commercemarket.controller.order.dto.OrderResponseDto;
 import flab.commercemarket.domain.user.vo.User;
 import lombok.*;
+import org.hibernate.annotations.BatchSize;
 
 import javax.persistence.*;
 import java.math.BigDecimal;
@@ -26,6 +27,7 @@ public class Order {
     @JoinColumn(name = "buyer_id")
     private User user;
 
+    @BatchSize(size = 5)
     @OneToMany(cascade = CascadeType.PERSIST)
     @JoinColumn(name = "order_id")
     private List<OrderProduct> orderProduct;

--- a/src/main/java/flab/commercemarket/domain/order/vo/Order.java
+++ b/src/main/java/flab/commercemarket/domain/order/vo/Order.java
@@ -1,16 +1,15 @@
 package flab.commercemarket.domain.order.vo;
 
+import flab.commercemarket.controller.order.dto.OrderGetResponseDto;
 import flab.commercemarket.controller.order.dto.OrderResponseDto;
 import flab.commercemarket.domain.user.vo.User;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import javax.persistence.*;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Entity(name = "MARKET_ORDER")
 @Getter
@@ -31,8 +30,6 @@ public class Order {
     @JoinColumn(name = "order_id")
     private List<OrderProduct> orderProduct;
 
-    private String requestMessage;
-
     private LocalDateTime orderedAt;
 
     private BigDecimal orderPrice;
@@ -43,9 +40,19 @@ public class Order {
     public OrderResponseDto toOrderResponseDto() {
         return OrderResponseDto.builder()
                 .id(id)
-                .userId(user.getId())
+                .user(user)
                 .orderProduct(orderProduct)
-                .requestMessage(requestMessage)
+                .orderedAt(orderedAt)
+                .orderPrice(orderPrice)
+                .merchantUid(merchantUid)
+                .build();
+    }
+
+    public OrderGetResponseDto toOrderGetResponseDto() {
+        return OrderGetResponseDto.builder()
+                .id(id)
+                .user(user.toUserResponseDto())
+                .orderProductDto(orderProduct.stream().map(OrderProduct::toOrderProductDto).collect(Collectors.toList()))
                 .orderedAt(orderedAt)
                 .orderPrice(orderPrice)
                 .merchantUid(merchantUid)

--- a/src/main/java/flab/commercemarket/domain/order/vo/OrderProduct.java
+++ b/src/main/java/flab/commercemarket/domain/order/vo/OrderProduct.java
@@ -1,13 +1,10 @@
 package flab.commercemarket.domain.order.vo;
 
+import flab.commercemarket.controller.order.dto.OrderProductDto;
 import flab.commercemarket.domain.product.vo.Product;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import javax.persistence.*;
-import java.math.BigDecimal;
 
 @Entity
 @Getter
@@ -23,11 +20,17 @@ public class OrderProduct {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "product_id")
     private Product product;
 
     private int quantity;
 
-    private BigDecimal totalPrice;
+    public OrderProductDto toOrderProductDto() {
+        return OrderProductDto.builder()
+                .id(id)
+                .productResponseDto(product.toProductResponseDto())
+                .quantity(quantity)
+                .build();
+    }
 }

--- a/src/main/java/flab/commercemarket/domain/product/vo/Product.java
+++ b/src/main/java/flab/commercemarket/domain/product/vo/Product.java
@@ -23,7 +23,6 @@ public class Product {
     private int price;
     private String imageUrl;
     private String description;
-    private int stockAmount;
     private int likeCount;
 
     @ManyToOne

--- a/src/main/java/flab/commercemarket/domain/wishlist/WishListService.java
+++ b/src/main/java/flab/commercemarket/domain/wishlist/WishListService.java
@@ -33,7 +33,7 @@ public class WishListService {
         log.info("Start registerWishList");
         User foundUser = userService.getUserByEmail(email);
 
-        Product foundProduct = productService.getProduct(productId);
+        Product foundProduct = productService.getProductById(productId);
         verifyDuplicatedWishList(foundUser.getId(), productId);
 
         WishList wishList = WishList.builder()

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,12 +1,12 @@
 spring:
   datasource:
     master:
-      url: jdbc:mysql://localhost:57015/market
+      url: jdbc:mysql://localhost:53152/market
       username: ENC(0TzQJZvEE7TpaAexvkbLwA==)
       password: ENC(OI5c6BncKMZXJabXAubyfw==)
       driver-class-name: ENC(Bhpswp3jpRS+YqAIXt+8U94M6BqOWpdQP1osszD1FqUBG6SxUMgtDw==)
     slave:
-      url: jdbc:mysql://localhost:57018/market
+      url: jdbc:mysql://localhost:53154/market
       username: ENC(03gowqi1UzWEEWdc13bX+A==)
       password: ENC(GOoxTZARqOXfIVa+NWeuSw==)
       driver-class-name: ENC(Bhpswp3jpRS+YqAIXt+8U94M6BqOWpdQP1osszD1FqUBG6SxUMgtDw==)

--- a/src/test/java/flab/commercemarket/service/ProductServiceTest.java
+++ b/src/test/java/flab/commercemarket/service/ProductServiceTest.java
@@ -47,6 +47,8 @@ public class ProductServiceTest {
 
     ProductDto productDto;
 
+    String email;
+
     @BeforeEach
     void init() {
         seller = User.builder()
@@ -60,8 +62,9 @@ public class ProductServiceTest {
                 "product name",
                 10000,
                 "product picture",
-                "product description",
-                seller.getId());
+                "product description");
+
+        email = "abc@gmail.com";
     }
 
     @Test
@@ -70,11 +73,11 @@ public class ProductServiceTest {
         // given
         Product product = productFixture(1L);
 
-        when(userService.getUserById(productDto.getSellerId())).thenReturn(seller);
+        when(userService.getUserByEmail(email)).thenReturn(seller);
         when(productRepository.save(any(Product.class))).thenReturn(product);
 
         // when
-        Product registeredProduct = productService.registerProduct(productDto);
+        Product registeredProduct = productService.registerProduct(email, productDto);
 
         // then
         assertNotNull(registeredProduct);
@@ -93,16 +96,16 @@ public class ProductServiceTest {
         Product product = productFixture(productId);
 
         when(productRepository.findById(productId)).thenReturn(Optional.of(product));
+        when(userService.getUserByEmail(email)).thenReturn(seller);
         ProductDto changeProduct = new ProductDto(
                 "change product name",
                 100,
                 "change product picture",
-                "change product description",
-                seller.getId()
+                "change product description"
         );
 
         // when
-        Product updatedProduct = productService.updateProduct(productId, changeProduct);
+        Product updatedProduct = productService.updateProduct(email, productId, changeProduct);
 
         // then
         assertNotNull(updatedProduct);
@@ -124,7 +127,7 @@ public class ProductServiceTest {
 
         // then
         assertThrows(DataNotFoundException.class, () -> {
-            productService.updateProduct(productId, productDto);
+            productService.updateProduct(email, productId, productDto);
         });
     }
 
@@ -205,13 +208,13 @@ public class ProductServiceTest {
     public void deleteProductTest() {
         // given
         long productId = 1L;
-        Product product = new Product(); // 가상의 제품 객체
+        Product product = productFixture(productId); // 가상의 제품 객체
 
-        when(productRepository.findById(productId))
-                .thenReturn(Optional.of(product));
+        when(productRepository.findById(productId)).thenReturn(Optional.of(product));
+        when(userService.getUserByEmail(email)).thenReturn(seller);
 
         // when
-        productService.deleteProduct(productId);
+        productService.deleteProduct(productId, email);
 
         // then
         verify(productRepository, times(1)).delete(eq(product));


### PR DESCRIPTION
# N+1 문제 해결


### 목적
N+1 문제를 해결하여 불필요한 데이터베이스 액세스를 줄입니다.

### 내용
BatchSize 어노테이션을 활용하여 상위엔티티 조회시 하위 엔티티를 함께 로딩합니다.

### 영향
추가 쿼리가 발생하지 않습니다.

### 관련 이슈
#74 

### 참고 사항
- 연관관계를 LAZY로 바꾸면서 코드 수정 내용이 많아졌습니다.
https://velog.io/@taebong98/n1-trouble-shooting

### 리뷰포인트
- Order 클래스의 `@BatchSize(size=5)` 설정으로 N+1 문제를 해결했습니다.